### PR TITLE
update repo org from 10up to globeandmail

### DIFF
--- a/.github/hookdoc-tmpl/README.md
+++ b/.github/hookdoc-tmpl/README.md
@@ -4,6 +4,6 @@ This resource is generated documentation on actions and filters found in the Sop
 
 For more information about using Sophi for WordPress, please see the [Sophi website](https://sophi.io/).
 
-To report an issue with Sophi for WordPress or contribute back to the project, please visit the [GitHub repository](https://github.com/10up/sophi-for-wordpress/).
+To report an issue with Sophi for WordPress or contribute back to the project, please visit the [GitHub repository](https://github.com/globeandmail/sophi-for-wordpress/).
 
-<a href="http://10up.com/contact/" class="banner"><img src="https://10up.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>
+<a href="https://www.sophi.io/contact/" class="banner"><img src="https://raw.githubusercontent.com/globeandmail/sophi-for-wordpress/develop/.wordpress-org/banner-1544x500.png?token=AAVQAVOFCCNY7MWUHRZLYNTAOR6JI" width="850"></a>

--- a/.github/hookdoc-tmpl/layout.tmpl
+++ b/.github/hookdoc-tmpl/layout.tmpl
@@ -28,8 +28,8 @@
 
     <footer>
 		<a href="https://sophi.io/">Sophi.io</a> &bull;
-		<a href="https://github.com/10up/sophi-for-wordpress/">Sophi for WordPress on GitHub</a> &bull;
-		<a href="https://10up.com/careers">Careers at 10up</a>
+		<a href="https://github.com/globeandmail/sophi-for-wordpress/">Sophi for WordPress on GitHub</a> &bull;
+		<a href="https://www.sophi.io/careers/">Careers at Sophi</a>
 	</footer>
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@ All notable changes to this project will be documented in this file, per [the Ke
 ## [0.1.0] - TBD
 - First release
 
-[Unreleased]: https://github.com/10up/sophi-for-wordpress/compare/trunk...develop
-[1.0.0]: https://github.com/10up/sophi-for-wordpress/compare/0.1.0...1.0.0
-[0.1.0]: https://github.com/10up/sophi-for-wordpress/tree/COMMIT-HASH-HERE
+[Unreleased]: https://github.com/globeandmail/sophi-for-wordpress/compare/trunk...develop
+[1.0.0]: https://github.com/globeandmail/sophi-for-wordpress/compare/0.1.0...1.0.0
+[0.1.0]: https://github.com/globeandmail/sophi-for-wordpress/tree/COMMIT-HASH-HERE

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at opensource@10up.com. All
+reported by contacting the project team at info@sophi.io. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,17 +10,17 @@ Contributing isn't just writing code - it's anything that improves the project. 
 
 ### Reporting bugs
 
-If you're running into an issue with the plugin, please take a look through [existing issues](https://github.com/10up/sophi-for-wordpress/issues) and [open a new one](https://github.com/10up/sophi-for-wordpress/issues/new) if needed.  If you're able, include steps to reproduce, environment information, and screenshots/screencasts as relevant.
+If you're running into an issue with the plugin, please take a look through [existing issues](https://github.com/globeandmail/sophi-for-wordpress/issues) and [open a new one](https://github.com/globeandmail/sophi-for-wordpress/issues/new) if needed.  If you're able, include steps to reproduce, environment information, and screenshots/screencasts as relevant.
 
 ### Suggesting enhancements
 
-New features and enhancements are also managed via [issues](https://github.com/10up/sophi-for-wordpress/issues).
+New features and enhancements are also managed via [issues](https://github.com/globeandmail/sophi-for-wordpress/issues).
 
 ### Pull requests
 
 Pull requests represent a proposed solution to a specified problem.  They should always reference an issue that describes the problem and contains discussion about the problem itself.  Discussion on pull requests should be limited to the pull request itself, i.e. code review.
 
-For more on how 10up writes and manages code, check out our [10up Engineering Best Practices](https://10up.github.io/Engineering-Best-Practices/).
+For more on how 10up writes and manages code, check out the [10up Engineering Best Practices](https://10up.github.io/Engineering-Best-Practices/).
 
 ## Workflow
 
@@ -37,6 +37,6 @@ The `develop` branch is the development branch which means it contains the next 
 1. Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then do the same for `develop` into `trunk` (`git checkout trunk && git merge --no-ff develop`). `trunk` contains the stable development version.
 1. Test: While still on the `trunk` branch, test for functionality locally.
 1. Push: Push your `trunk` branch to GitHub (e.g. `git push origin trunk`).
-1. Release: Create a [new release](https://github.com/10up/sophi-for-wordpress/releases/new), naming the tag and the release with the new version number, and targeting the `trunk` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the [closed issues on the milestone](https://github.com/10up/sophi-for-wordpress/milestone/#?closed=1).
-1. Close the milestone: Edit the [milestone](https://github.com/10up/sophi-for-wordpress/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the milestone.
+1. Release: Create a [new release](https://github.com/globeandmail/sophi-for-wordpress/releases/new), naming the tag and the release with the new version number, and targeting the `trunk` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the [closed issues on the milestone](https://github.com/globeandmail/sophi-for-wordpress/milestone/#?closed=1).
+1. Close the milestone: Edit the [milestone](https://github.com/globeandmail/sophi-for-wordpress/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the milestone.
 1. Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X+1.0.0`, `X.Y+1.0`, `X.Y.Z+1`, or `Future Release`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > WordPress VIP-compatible plugin for the Sophi.io Curator service.
 
-[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/sophi-for-wordpress.svg)](https://github.com/10up/sophi-for-wordpress/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.6%20tested-success.svg) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/sophi-for-wordpress.svg)](https://github.com/10up/sophi-for-wordpress/blob/trunk/LICENSE.md)
+[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/globeandmail/sophi-for-wordpress.svg)](https://github.com/globeandmail/sophi-for-wordpress/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.6%20tested-success.svg) [![GPL-2.0-or-later License](https://img.shields.io/github/license/globeandmail/sophi-for-wordpress.svg)](https://github.com/globeandmail/sophi-for-wordpress/blob/trunk/LICENSE.md)
 
 ## Developers
 
@@ -39,15 +39,15 @@ If you're looking to contribute to or extend the Sophi for WordPress plugin, the
 
 ## Support Level
 
-**Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.
+**Active:** The Globe and Mail is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.
 
 ## Changelog
 
-A complete listing of all notable changes to Sophi for WordPress are documented in [CHANGELOG.md](https://github.com/10up/sophi-for-wordpress/blob/develop/CHANGELOG.md).
+A complete listing of all notable changes to Sophi for WordPress are documented in [CHANGELOG.md](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CHANGELOG.md).
 
 ## Contributing
 
-Please read [CODE_OF_CONDUCT.md](https://github.com/10up/sophi-for-wordpress/blob/develop/CODE_OF_CONDUCT.md) for details on our code of conduct, [CONTRIBUTING.md](https://github.com/10up/sophi-for-wordpress/blob/develop/CONTRIBUTING.md) for details on the process for submitting pull requests to us, and [CREDITS.md](https://github.com/10up/sophi-for-wordpress/blob/develop/CREDITS.md) for a listing of maintainers, contributors, and libraries for Sophi for WordPress.
+Please read [CODE_OF_CONDUCT.md](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CODE_OF_CONDUCT.md) for details on our code of conduct, [CONTRIBUTING.md](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CONTRIBUTING.md) for details on the process for submitting pull requests to us, and [CREDITS.md](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CREDITS.md) for a listing of maintainers, contributors, and libraries for Sophi for WordPress.
 
 ## Like what you see?
 

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-  "name": "10up/sophi-wp",
+  "name": "globeandmail/sophi-wp",
   "description": "WordPress VIP-compatible plugin for the Sophi.io Curator service.",
   "type": "wordpress-plugin",
-  "homepage": "https://github.com/10up/sophi-for-wordpress",
-  "readme": "https://github.com/10up/sophi-for-wordpress/blob/develop/README.md",
+  "homepage": "https://github.com/globeandmail/sophi-for-wordpress",
+  "readme": "https://github.com/globeandmail/sophi-for-wordpress/blob/develop/README.md",
   "license": "GPL-2.0-or-later",
   "authors": [
     {
@@ -20,7 +20,7 @@
     }
   ],
   "support": {
-    "issues": "https://github.com/10up/sophi-for-wordpress/issues"
+    "issues": "https://github.com/globeandmail/sophi-for-wordpress/issues"
   },
   "require": {
     "php": ">=7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@10up/sophi-wp",
+  "name": "@globeandmail/sophi-wp",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@10up/sophi-wp",
+  "name": "@globeandmail/sophi-wp",
   "version": "0.1.0",
   "description": "WordPress VIP-compatible plugin for the Sophi.io Curator service.",
-  "homepage": "https://github.com/10up/sophi-for-wordpress",
+  "homepage": "https://github.com/globeandmail/sophi-for-wordpress",
   "bugs": {
-    "url": "https://github.com/10up/sophi-for-wordpress/issues"
+    "url": "https://github.com/globeandmail/sophi-for-wordpress/issues"
   },
   "license": "GPL-2.0-or-later",
   "author": {
@@ -21,7 +21,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/10up/sophi-for-wordpress"
+    "url": "https://github.com/globeandmail/sophi-for-wordpress"
   },
   "scripts": {
     "test": "phpunit",

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
-=== 10up Plugin Scaffold ===
+=== Sophi for WordPress ===
 Contributors:      10up
-Tags:              Sophi, Curator, AI, Artifical Intelligence, ML, Machine Learning, Content Curation
+Tags:              Sophi, Curator, Collector, AI, Artifical Intelligence, ML, Machine Learning, Content Curation
 Requires at least: 5.6
 Tested up to:      5.6
 Requires PHP:      7.4
@@ -32,7 +32,7 @@ stable.
 = Manual Installation =
 
 1. Upload the entire `/sophi-wp` directory to the `/wp-content/plugins/` directory.
-2. Activate 10up Scaffold through the 'Plugins' menu in WordPress.
+2. Activate Sophi for WordPress through the 'Plugins' menu in WordPress.
 
 == Frequently Asked Questions ==
 

--- a/sophi-for-wordpress.php
+++ b/sophi-for-wordpress.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       Sophi for WordPress
- * Plugin URI:        https://github.com/10up/sophi-for-wordpress
+ * Plugin URI:        https://github.com/globeandmail/sophi-for-wordpress
  * Description:       WordPress VIP-compatible plugin for the Sophi.io Curator service.
  * Version:           0.1.0
  * Requires at least: 5.6


### PR DESCRIPTION
Updates the GitHub repo organization from `10up` to `globeandmail` to match the updated location, plus some minor changes from 10up-related references/content to Sophi-related references/content.

Resolves #16.