### PR TITLE
add deploy and asset update actions

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,28 @@
+# Directories
+/.git
+/.github
+/.wordpress-org
+/node_modules
+/tests
+/assets
+/config
+# DO NOT EXCLUDE /vendor
+
+# Files
+.distignore
+.eslintignore
+.eslintrc.json
+.gitignore
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+composer.json
+composer.lock
+CONTRIBUTING.md
+CREDITS.md
+hookdoc-conf.json
+LICENSE.md
+package-lock.json
+package.json
+phpcs.xml
+phpunit.xml
+README.md

--- a/.distignore
+++ b/.distignore
@@ -2,14 +2,15 @@
 /.git
 /.github
 /.wordpress-org
-/node_modules
-/tests
 /assets
 /config
+/node_modules
+/tests
 # DO NOT EXCLUDE /vendor
 
 # Files
 .distignore
+.editorconfig
 .eslintignore
 .eslintrc.json
 .gitignore

--- a/.github/workflows/dotorg-asset-readme-update.yml
+++ b/.github/workflows/dotorg-asset-readme-update.yml
@@ -1,0 +1,16 @@
+name: Plugin asset/readme update
+on:
+  push:
+    branches:
+    - trunk
+jobs:
+  trunk:
+    name: Push to trunk
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@stable
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/dotorg-push-deploy.yml
+++ b/.github/workflows/dotorg-push-deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to WordPress.org
+on:
+  release:
+    types: [published]
+jobs:
+  tag:
+    name: New release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set Node.js 12
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: composer install
+      run: composer install --no-dev
+    - name: Build
+      run: |
+        npm install
+        npm run build
+    - name: WordPress Plugin Deploy
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      with:
+        generate-zip: true
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+    - name: Upload release asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{github.workspace}}/${{ github.event.repository.name }}.zip
+        asset_name: ${{ github.event.repository.name }}.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds the WP.org deploy and readme/asset update actions to ensure we can automate future releases to the dotorg repo.  Note that we'll still need to add the Sophi.io `SVN_USERNAME` and `SVN_PASSWORD` secrets to this repo once that WordPress.org account is created.

### Alternate Designs

none really, but I suppose we could manually deploy to SVN but why?

### Benefits

Speeds up releases to WP.org.

### Possible Drawbacks

none identified

### Verification Process

none, our next release will validate this deploy works

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

```
### Added
- GitHub Actions to deploy releases and update readme/asset changes for WordPress.org
```
