### PR TITLE
Rename/sophi

### DIFF
--- a/.github/hookdoc-tmpl/layout.tmpl
+++ b/.github/hookdoc-tmpl/layout.tmpl
@@ -29,6 +29,7 @@
     <footer>
 		<a href="https://sophi.io/">Sophi.io</a> &bull;
 		<a href="https://github.com/globeandmail/sophi-for-wordpress/">Sophi for WordPress on GitHub</a> &bull;
+    <a href="https://wordpress.org/plugins/sophi/">Sophi on WordPress.org</a> &bull;
 		<a href="https://www.sophi.io/careers/">Careers at Sophi</a>
 	</footer>
 

--- a/.github/workflows/dotorg-asset-readme-update.yml
+++ b/.github/workflows/dotorg-asset-readme-update.yml
@@ -14,3 +14,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: sophi

--- a/.github/workflows/dotorg-push-deploy.yml
+++ b/.github/workflows/dotorg-push-deploy.yml
@@ -27,6 +27,7 @@ jobs:
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SLUG: sophi
     - name: Upload release asset
       uses: actions/upload-release-asset@v1
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/), and will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- `noConfigFile` setting (props [@dinhtungdu](https://github.com/dinhtungdu) via [#48](https://github.com/globeandmail/sophi-for-wordpress/pull/48))
+- GitHub Actions to deploy releases and update readme/asset changes for WordPress.org (props [@jeffpaul](https://github.com/jeffpaul), [@dinhtungdu](https://github.com/dinhtungdu) via [#44](https://github.com/globeandmail/sophi-for-wordpress/pull/44))
 
 ## [1.0.0] - 2021-04-14
 - Initial public release! 🎉
 
 [Unreleased]: https://github.com/globeandmail/sophi-for-wordpress/compare/trunk...develop
-[1.1.0]: https://github.com/globeandmail/sophi-for-wordpress/compare/1.0.0...1.1.0
-[1.0.0]: https://github.com/globeandmail/sophi-for-wordpress/tree/COMMIT-HASH-HERE
+[1.0.1]: https://github.com/globeandmail/sophi-for-wordpress/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/globeandmail/sophi-for-wordpress/tree/3e714c0149a3b3e4a209c9d71b1510e43c42efcd

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ The `develop` branch is the development branch which means it contains the next 
 ## Release instructions
 
 1. Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-1. Version bump: Bump the version number in `sophi-for-wordpress.php`, `package.json`, and `readme.txt` if it does not already reflect the version being released.  Update both the plugin "Version:" property and the plugin `SOPHI_WP_VERSION` constant in `sophi-for-wordpress.php`.
+1. Version bump: Bump the version number in `sophi.php`, `package.json`, and `readme.txt` if it does not already reflect the version being released.  Update both the plugin "Version:" property and the plugin `SOPHI_WP_VERSION` constant in `sophi.php`.
 1. Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`.
 1. Props: update `CREDITS.md` with any new contributors, confirm maintainers are accurate.
 1. Readme updates: Make any other readme changes as necessary.  `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content.  The two are slightly different.
@@ -42,4 +42,4 @@ The `develop` branch is the development branch which means it contains the next 
 1. Release: Create a [new release](https://github.com/globeandmail/sophi-for-wordpress/releases/new), naming the tag and the release with the new version number, and **targeting the `stable` branch**.  Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the [closed issues on the milestone](https://github.com/globeandmail/sophi-for-wordpress/milestone/#?closed=1).
 1. Close the milestone: Edit the [milestone](https://github.com/globeandmail/sophi-for-wordpress/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the milestone.
 1. Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X+1.0.0`, `X.Y+1.0`, `X.Y.Z+1`, or `Future Release`.
-1. Version bump (again): In the `develop` branch (`cd ../ && git checkout develop`) bump the version number in `sophi-for-wordpress.php` to `X.Y.(Z+1)-dev`.  It's okay if the next release might be a different version number; that change can be handled right before release in the first step, as might also be the case with ``@since` annotations.
+1. Version bump (again): In the `develop` branch (`cd ../ && git checkout develop`) bump the version number in `sophi.php` to `X.Y.(Z+1)-dev`.  It's okay if the next release might be a different version number; that change can be handled right before release in the first step, as might also be the case with ``@since` annotations.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "globeandmail/sophi-wp",
+  "name": "globeandmail/sophi-for-wordpress",
   "description": "WordPress VIP-compatible plugin for the Sophi.io Site Automation service.",
   "type": "wordpress-plugin",
   "homepage": "https://github.com/globeandmail/sophi-for-wordpress",

--- a/includes/functions/settings.php
+++ b/includes/functions/settings.php
@@ -24,7 +24,7 @@ function setup() {
 
 	add_action( 'admin_menu', $n( 'settings_page' ) );
 	add_action( 'admin_init', $n( 'fields_setup' ) );
-	add_filter( 'plugin_action_links_' . plugin_basename( SOPHI_WP_PATH . '/sophi-for-wordpress.php' ), $n( 'add_action_links' ) );
+	add_filter( 'plugin_action_links_' . plugin_basename( SOPHI_WP_PATH . '/sophi.php' ), $n( 'add_action_links' ) );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@globeandmail/sophi-wp",
+  "name": "@globeandmail/sophi-for-wordpress",
   "version": "1.0.0",
   "description": "WordPress VIP-compatible plugin for the Sophi.io Site Automation service.",
   "homepage": "https://github.com/globeandmail/sophi-for-wordpress",
@@ -27,7 +27,7 @@
     "start": "10up-scripts start",
     "watch": "10up-scripts watch",
     "build": "10up-scripts build",
-    "build:docs": "rm -rf docs && jsdoc -c hookdoc-conf.json sophi-for-wordpress.php includes",
+    "build:docs": "rm -rf docs && jsdoc -c hookdoc-conf.json sophi.php includes",
     "format-js": "10up-scripts format-js",
     "lint-js": "10up-scripts lint-js",
     "lint-style": "10up-scripts lint-style",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,7 @@
 	<file>assets/js/</file>
 	<file>includes/</file>
 	<file>tests/</file>
-	<file>sophi-for-wordpress.php</file>
+	<file>sophi.php</file>
 	<exclude-pattern>assets/js/frontend/sophi-tag.js</exclude-pattern>
 	<rule ref="WordPress-VIP-Go" />
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Sophi for WordPress ===
+=== Sophi ===
 Contributors:      10up
 Tags:              Sophi, Site Automation, Collector, AI, Artifical Intelligence, ML, Machine Learning, Content Curation
 Requires at least: 5.6

--- a/sophi.php
+++ b/sophi.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:       Sophi for WordPress
+ * Plugin Name:       Sophi
  * Plugin URI:        https://github.com/globeandmail/sophi-for-wordpress
  * Description:       WordPress VIP-compatible plugin for the Sophi.io Site Automation service.
  * Version:           1.0.1-dev


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR removes "for WordPress" from the plugin displayname and main plugin file name to meet WordPress.org naming requirements.  I've purposely left `sophi-for-wordpress` as the repo name so that when viewed from the main `globeandmail` org perspective its clear that its the WordPress plugin and not some main Sophi.io repo.

### Alternate Designs

n/a

### Benefits

Ensures we meet WP.org naming standards to be included in their repo.

### Possible Drawbacks

none identified

### Verification Process

Manually verified via Atom and GitHub Desktop UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

```
### Changed
- Renamed plugin from `Sophi for WordPress` to `Sophi`.
```
