### PR TITLE
Remove scheme from default collector URL

### DIFF
--- a/includes/functions/settings.php
+++ b/includes/functions/settings.php
@@ -209,7 +209,7 @@ function fields_setup() {
 function get_default_settings( $key = '' ) {
 	$default = [
 		'environment'         => 'prod',
-		'collector_url'       => 'https://collector.sophi.io',
+		'collector_url'       => 'collector.sophi.io',
 		'tracker_client_id'   => get_domain(),
 		'client_id'           => '',
 		'client_secret'       => '',


### PR DESCRIPTION
Replaces `https://collector.sophi.io` with `collector.sophi.io`

The settings screen collector URL input field's help text asks for a URL without "https", so let's remove it from the default URL that is inserted in that field.
