### PR TITLE
Fix: Unconfigured plugin loads snowplow analytics

### DIFF
--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -99,7 +99,9 @@ function track_event( $new_status, $old_status, $post ) {
  * @return Tracker|WP_Error
  */
 function init_tracker() {
-	$collector_url = get_sophi_settings( 'collector_url' );
+	$collector_url     = get_sophi_settings( 'collector_url' );
+	$tracker_client_id = get_sophi_settings( 'tracker_client_id' );
+
 	if ( ! $collector_url ) {
 		return new WP_Error(
 			'sophi_missing_collector_url',
@@ -107,7 +109,14 @@ function init_tracker() {
 		);
 	}
 
-	$app_id  = sprintf( '%s-cms', get_sophi_settings( 'tracker_client_id' ) );
+	if ( ! $tracker_client_id ) {
+		return new WP_Error(
+			'sophi_missing_tracker_client_id',
+			'The Tracker Client ID is missing.'
+		);
+	}
+
+	$app_id  = sprintf( '%s-cms', $tracker_client_id );
 	$emitter = new SyncEmitter( $collector_url, 'https', 'POST', 1, false );
 	$subject = new Subject();
 	return new Tracker( $emitter, $subject, 'sophiTag', $app_id, false );

--- a/includes/functions/settings.php
+++ b/includes/functions/settings.php
@@ -9,6 +9,7 @@ namespace SophiWP\Settings;
 
 use SophiWP\SiteAutomation\Auth;
 use function SophiWP\Utils\get_domain;
+use function SophiWP\Utils\is_configured;
 
 const SETTINGS_GROUP = 'sophi_settings';
 
@@ -391,9 +392,14 @@ function render_select( $args ) {
  * @return array
  */
 function add_action_links ( $actions ) {
+	if ( ! is_configured() ) {
+		$action_label = __('Set up your Sophi.io account', 'sophi-wp');
+	} else {
+		$action_label = __('Settings', 'sophi-wp');
+	}
 	return array_merge(
 		[
-			'<a href="' . admin_url('options-general.php?page=sophi') . '">' . __('Set up your Sophi.io account', 'sophi-wp') . '</a>',
+			'<a href="' . admin_url('options-general.php?page=sophi') . '">' . $action_label . '</a>',
 		],
 		$actions
 	);

--- a/includes/functions/settings.php
+++ b/includes/functions/settings.php
@@ -209,8 +209,8 @@ function fields_setup() {
 function get_default_settings( $key = '' ) {
 	$default = [
 		'environment'         => 'prod',
-		'collector_url'       => '',
-		'tracker_client_id'   => '',
+		'collector_url'       => 'collector.sophi.io',
+		'tracker_client_id'   => get_domain(),
 		'client_id'           => '',
 		'client_secret'       => '',
 		'site_automation_url' => '',

--- a/includes/functions/settings.php
+++ b/includes/functions/settings.php
@@ -209,8 +209,8 @@ function fields_setup() {
 function get_default_settings( $key = '' ) {
 	$default = [
 		'environment'         => 'prod',
-		'collector_url'       => 'collector.sophi.io',
-		'tracker_client_id'   => get_domain(),
+		'collector_url'       => '',
+		'tracker_client_id'   => '',
 		'client_id'           => '',
 		'client_secret'       => '',
 		'site_automation_url' => '',

--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -7,6 +7,8 @@
 
 namespace SophiWP\Utils;
 
+use function SophiWP\Settings\get_sophi_settings;
+
 /**
  * Get breadcrumbs from the post URL.
  *
@@ -186,4 +188,24 @@ function get_supported_post_types() {
 	 * @return {array} Supported post types.
 	 */
 	return apply_filters( 'sophi_supported_post_types', [ 'post', 'page' ] );
+}
+
+function is_configured() {
+	$settings = get_sophi_settings();
+
+	unset( $settings['environment'] );
+	unset( $settings['query_integration'] );
+
+	$settings = array_filter(
+		$settings,
+		function( $item ) {
+			return empty( $item );
+		}
+	);
+
+	if ( count( $settings ) > 0 ) {
+		return false;
+	} else {
+		return true;
+	}
 }

--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -190,6 +190,11 @@ function get_supported_post_types() {
 	return apply_filters( 'sophi_supported_post_types', [ 'post', 'page' ] );
 }
 
+/**
+ * Check if Sophi is configured or not.
+ *
+ * @return bool
+ */
 function is_configured() {
 	$settings = get_sophi_settings();
 

--- a/sophi.php
+++ b/sophi.php
@@ -61,6 +61,11 @@ add_action(
 			// Bootstrap.
 			SophiWP\Core\setup();
 			SophiWP\Settings\setup();
+
+			if ( ! SophiWP\Utils\is_configured() ) {
+				return add_action( 'admin_notices', 'sophi_setup_notice' );
+			}
+
 			SophiWP\ContentSync\setup();
 			SophiWP\Tracking\setup();
 			SophiWP\Blocks\setup();
@@ -82,16 +87,39 @@ add_action(
 			 */
 			do_action( 'sophi_loaded' );
 		} else {
-			add_action(
-				'admin_notices',
-				function() {
-					?>
-				<div class="notice notice-error">
-						<p><?php esc_html_e( 'Sophi requires HTTPS. Please install SSL to your site and try again.', 'sophi-wp' ); ?></p>
-				</div>
-					<?php
-				}
-			);
+			add_action( 'admin_notices', 'sophi_https_notice' );
 		}
 	}
 );
+
+/**
+ * Sophi HTTPS notice.
+ */
+function sophi_https_notice() {
+	$screen = get_current_screen();
+	if ( 'plugins' !== $screen->id ) {
+		return;
+	}
+	?>
+		<div class="notice notice-error">
+			<p><?php esc_html_e( 'Sophi requires HTTPS. Please install SSL to your site and try again.', 'sophi-wp' ); ?></p>
+		</div>
+	<?php
+}
+
+
+/**
+ * Sophi setup notice.
+ */
+function sophi_setup_notice() {
+	$screen = get_current_screen();
+	if ( 'plugins' !== $screen->id ) {
+		return;
+	}
+	?>
+		<div class="notice notice-error">
+				<p><?php echo wp_kses_post( sprintf( __( 'Please set up your Sophi.io account in Settings > <a href="%s">Sophi.io</a>', 'sophi-wp' ), admin_url( 'options-general.php?page=sophi' ) ) ); ?></p>
+		</div>
+	<?php
+
+}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes #58 by ensuring all required settings are set before enabling plugin's functionalities. This PR also add new notice asking users to setup the credentials after activating the plugin.
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Verification Process
1. Activate Sophi on a new site.
2. See new notice asking user setup the credentials.
3. Setup the credentials.
4. Go back to the plugins page. See no notice.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
Closes #58 
<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
