### PR TITLE
More content schema updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,28 @@ Note that you need to add `data-sophi-feature=<widget_name>` to the wrapper div 
 </div>
 ```
 
+### Post content type
+
+By default, Sophi for WordPress uses post format as the content type. This plugin uses `content_type` internally to distinguish between WordPress post type and Sophi type.
+
+Sophi accepts 4 types: article, video, audio, and image. The default type is `article`. Any other types that are not included above will be treated as `article`.
+
+If you're not using post format for content type, you can utilize `sophi_post_content_type` to set the content type.
+
+```php
+add_filter( 'sophi_post_content_type', function( $type, $post ) {
+	// You logic here.
+
+	return $new_type;
+} );
+```
+
+### Canonical URL
+
+Sophi for WordPress uses `wp_get_canonical_url` function introduced in WordPress 4.6 to get the canonical URL for given post. The plugin compares this canonical URL to post permalink to set the `isCanonical` attribute.
+
+WordPress SEO (Yoast) canonical is supported out of the box. For other SEO plugins and custom implementations, [`get_canonical_url`](https://developer.wordpress.org/reference/functions/wp_get_canonical_url/) filter can be used to change the canonical URL.
+
 ## Documentation
 
 Sophi for WordPress has an in-depth documentation site that details the available actions and filters found within the plugin. [Visit the hook docs ☞](https://globeandmail.github.io/sophi-for-wordpress/)

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -149,26 +149,8 @@ function init_tracker() {
  * @return array
  */
 function get_post_data( $post ) {
-	$content = apply_filters( 'the_content', get_the_content( null, false, $post ) );
-	$content = str_replace( ']]>', ']]&gt;', $content );
-
-	/**
-	 * Filter data type of the given post.
-	 *
-	 * @since 1.0.0
-	 * @hook sophi_post_data_type
-	 *
-	 * @param {string}  $type Post data type, one of article|video|audio|image
-	 * @param {WP_Post} $post WP_Post object.
-	 *
-	 * @return {string} Post data type.
-	 */
-	$type = apply_filters( 'sophi_post_data_type', get_post_format( $post ), $post );
-
-	if ( ! in_array( $type, [ 'video', 'audio', 'image' ], true ) ) {
-		$type = 'article';
-	}
-
+	$content       = apply_filters( 'the_content', get_the_content( null, false, $post ) );
+	$content       = str_replace( ']]>', ']]&gt;', $content );
 	$canonical_url = wp_get_canonical_url( $post );
 
 	// Support Yoast SEO canonical URL.
@@ -191,7 +173,7 @@ function get_post_data( $post ) {
 		'modifiedAt'     => gmdate( \DateTime::RFC3339, strtotime( $post->post_modified_gmt ) ),
 		'tags'           => Utils\get_post_tags( $post ),
 		'url'            => get_permalink( $post ),
-		'type'           => $type,
+		'type'           => Utils\get_post_data_type( $post ),
 		'isCanonical'    => untrailingslashit( $canonical_url ) === untrailingslashit( get_permalink( $post ) ),
 		'promoImageUri'  => get_the_post_thumbnail_url( $post, 'full' ),
 	];

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -167,7 +167,7 @@ function get_post_data( $post ) {
 		'accessCategory' => 'free access',
 		'publishedAt'    => gmdate( \DateTime::RFC3339, strtotime( $post->post_date_gmt ) ),
 		'plainText'      => wp_strip_all_tags( $content ),
-		'contentSize'    => str_word_count( wp_strip_all_tags( $content ) ),
+		'size'           => str_word_count( wp_strip_all_tags( $content ) ),
 		'sectionNames'   => Utils\get_section_names( Utils\get_post_breadcrumb( $post ) ),
 		'modifiedAt'     => gmdate( \DateTime::RFC3339, strtotime( $post->post_modified_gmt ) ),
 		'tags'           => Utils\get_post_tags( $post ),

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -173,7 +173,7 @@ function get_post_data( $post ) {
 		'modifiedAt'     => gmdate( \DateTime::RFC3339, strtotime( $post->post_modified_gmt ) ),
 		'tags'           => Utils\get_post_tags( $post ),
 		'url'            => get_permalink( $post ),
-		'type'           => Utils\get_post_data_type( $post ),
+		'type'           => Utils\get_post_content_type( $post ),
 		'isCanonical'    => untrailingslashit( $canonical_url ) === untrailingslashit( get_permalink( $post ) ),
 		'promoImageUri'  => get_the_post_thumbnail_url( $post, 'full' ),
 	];

--- a/includes/functions/tracking.php
+++ b/includes/functions/tracking.php
@@ -11,7 +11,7 @@ use function SophiWP\Settings\get_sophi_settings;
 use function SophiWP\Utils\get_domain;
 use function SophiWP\Utils\get_section_name;
 use function SophiWP\Utils\get_breadcrumb;
-use function SophiWP\Utils\get_post_data_type;
+use function SophiWP\Utils\get_post_content_type;
 use function SophiWP\Core\script_url;
 
 /**
@@ -84,11 +84,11 @@ function get_tracking_data() {
 				'version'     => get_bloginfo( 'version' ),
 			],
 			'page'        => [
-				'type'       => is_singular() ? get_post_data_type( $post ) : 'section',
+				'type'       => is_singular() ? get_post_content_type( $post ) : 'section',
 				'breadcrumb' => get_breadcrumb(),
 			],
 			'content'     => [
-				'type' => get_post_data_type( $post ),
+				'type' => get_post_content_type( $post ),
 			],
 		],
 		'settings' => [
@@ -220,14 +220,14 @@ function get_custom_contexts() {
 	global $post;
 
 	$page_data    = [
-		'type'       => is_singular() ? get_post_data_type( $post ) : 'section',
+		'type'       => is_singular() ? get_post_content_type( $post ) : 'section',
 		'breadcrumb' => get_breadcrumb(),
 		'sectionName' => get_section_name(),
 	];
 
 	if ( is_singular() ) {
 		$content_data = [
-			'type' => get_post_data_type( $post ),
+			'type' => get_post_content_type( $post ),
 			'contentId' => strval( $post->ID ),
 		];
 

--- a/includes/functions/tracking.php
+++ b/includes/functions/tracking.php
@@ -11,6 +11,7 @@ use function SophiWP\Settings\get_sophi_settings;
 use function SophiWP\Utils\get_domain;
 use function SophiWP\Utils\get_section_name;
 use function SophiWP\Utils\get_breadcrumb;
+use function SophiWP\Utils\get_post_data_type;
 use function SophiWP\Core\script_url;
 
 /**
@@ -83,11 +84,11 @@ function get_tracking_data() {
 				'version'     => get_bloginfo( 'version' ),
 			],
 			'page'        => [
-				'type'       => is_singular() ? 'article' : 'section',
+				'type'       => is_singular() ? get_post_data_type( $post ) : 'section',
 				'breadcrumb' => get_breadcrumb(),
 			],
 			'content'     => [
-				'type' => 'article',
+				'type' => get_post_data_type( $post ),
 			],
 		],
 		'settings' => [
@@ -219,14 +220,14 @@ function get_custom_contexts() {
 	global $post;
 
 	$page_data    = [
-		'type'       => is_singular() ? 'article' : 'section',
+		'type'       => is_singular() ? get_post_data_type( $post ) : 'section',
 		'breadcrumb' => get_breadcrumb(),
 		'sectionName' => get_section_name(),
 	];
 
 	if ( is_singular() ) {
 		$content_data = [
-			'type' => 'article',
+			'type' => get_post_data_type( $post ),
 			'contentId' => strval( $post->ID ),
 		];
 

--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -252,20 +252,20 @@ function is_configured() {
  *
  * @return string Post data type, can be article|video|audio|image
  */
-function get_post_data_type( $post ) {
+function get_post_content_type( $post ) {
 
 	/**
 	 * Filter data type of the given post.
 	 *
 	 * @since 1.0.0
-	 * @hook sophi_post_data_type
+	 * @hook sophi_post_content_type
 	 *
 	 * @param {string}  $type Post data type, one of article|video|audio|image
 	 * @param {WP_Post} $post WP_Post object.
 	 *
 	 * @return {string} Post data type.
 	 */
-	$type = apply_filters( 'sophi_post_data_type', get_post_format( $post ), $post );
+	$type = apply_filters( 'sophi_post_content_type', get_post_format( $post ), $post );
 
 	if ( ! in_array( $type, [ 'video', 'audio', 'image' ], true ) ) {
 		$type = 'article';

--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -242,3 +242,34 @@ function is_configured() {
 		return true;
 	}
 }
+
+/**
+ * Get post data type.
+ *
+ * @since 1.0.4
+ *
+ * @param WP_Post $post Post object.
+ *
+ * @return string Post data type, can be article|video|audio|image
+ */
+function get_post_data_type( $post ) {
+
+	/**
+	 * Filter data type of the given post.
+	 *
+	 * @since 1.0.0
+	 * @hook sophi_post_data_type
+	 *
+	 * @param {string}  $type Post data type, one of article|video|audio|image
+	 * @param {WP_Post} $post WP_Post object.
+	 *
+	 * @return {string} Post data type.
+	 */
+	$type = apply_filters( 'sophi_post_data_type', get_post_format( $post ), $post );
+
+	if ( ! in_array( $type, [ 'video', 'audio', 'image' ], true ) ) {
+		$type = 'article';
+	}
+
+	return $type;
+}


### PR DESCRIPTION
This PR continues the work in #70:

- Renamed `contentSize` to `size`.
- Updated AMP and JS tracking data to use post data type introduced in #65.
- Fixed the issue with Yoast (#70). Yoast updates the post meta after the core changes the post status. This is the reason why the canonical URL still is empty at the time we send the tracker event to Sophi. This PR ensures we only track content update events after the Yoast updating its meta.
- Changed post data type to post content type.
- Added documentation for post content type and canonical URL.