### PR TITLE
Fix: adding isCanonical lately after removing falsy items

### DIFF
--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -174,17 +174,13 @@ function get_post_data( $post ) {
 		'tags'           => Utils\get_post_tags( $post ),
 		'url'            => get_permalink( $post ),
 		'type'           => Utils\get_post_content_type( $post ),
-		'isCanonical'    => untrailingslashit( $canonical_url ) === untrailingslashit( get_permalink( $post ) ),
 		'promoImageUri'  => get_the_post_thumbnail_url( $post, 'full' ),
 	];
 
-	// Remove empty key, not false ones.
-	$data = array_filter(
-		$data,
-		function( $item ) {
-			return '' !== $item;
-		}
-	);
+	$data = array_filter( $data );
+
+	// Add canonical after filtering the falsy items.
+	$data['isCanonical'] = untrailingslashit( $canonical_url ) === untrailingslashit( get_permalink( $post ) );
 
 	/**
 	 * Filter post data for content sync events (aka "CMS updates" in Sophi.io terms) sent to Sophi Collector.  This allows control over data before it is sent to Collector in case it needs to be modified for unique site needs.  Note that if you add, change, or remove any fields with this that those changes will need to be coordinated with the Sophi.io team to ensure content is appropriately received by Collector.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->
In #71, we changed the tracking data sent to Sophi collector to send `isCanonical` value. This change introduces another issue: we're sending empty array and `false` values as well. We only need a boolean value for `isCanonical` field, so this PR reverts the change made in #71 and adds the `isCanonical` key after filtering the tracking data.

### Verification Process

Ensure the tracking data doesn't contain empty strings, empty arrays, and `false` (except `isCanonical` field).

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
