### PR TITLE
Fix: only use public hierarchial taxonomy for breadcrumb

### DIFF
--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -69,19 +69,19 @@ function get_post_breadcrumb( $post ) {
 
 	if ( count( $taxonomies ) > 0 ) {
 		/**
-		 * Filter the taxonomy to use to create breadcrumb. Default to the first public and hierarchial taxonomy
-		 * attached to the post.
+		 * Filter the hierarchial taxonomy to use to create breadcrumb. Default to the first
+		 * public and hierarchial taxonomy attached to the post.
 		 *
 		 * @since 1.0.4
 		 *
-		 * @hook sophi_taxonomy_for_breadcrumb
+		 * @hook sophi_hierarchial_taxonomy_for_breadcrumb
 		 *
 		 * @param {string}  $taxonomy Taxonomy used for breadcrumb.
 		 * @param {WP_Post} $post     Post object.
 		 *
 		 * @return {string} Taxonomy used for breadcrumb..
 		 */
-		$taxonomy = apply_filters( 'sophi_taxonomy_for_breadcrumb', $taxonomies[0], $post );
+		$taxonomy = apply_filters( 'sophi_hierarchial_taxonomy_for_breadcrumb', $taxonomies[0], $post );
 		$terms    = get_the_terms( $post, $taxonomy );
 
 		if ( count( $terms ) > 0 ) {
@@ -91,11 +91,27 @@ function get_post_breadcrumb( $post ) {
 		$non_hierarchial_taxonomies = array_filter(
 			get_object_taxonomies( $post ),
 			function( $taxonomy ) {
-				return ! is_taxonomy_hierarchical( $taxonomy );
+				$taxonomy_object = get_taxonomy( $taxonomy );
+				return ! $taxonomy_object->hierarchical && $taxonomy_object->public && $taxonomy_object->publicly_queryable;
 			}
 		);
+
 		if ( count( $non_hierarchial_taxonomies ) > 0 ) {
-			$terms = get_the_terms( $post, $non_hierarchial_taxonomies[0] );
+			/**
+			 * Filter the non hierarchial taxonomy to use to create breadcrumb. Default to the first
+			 * public and non hierarchial taxonomy attached to the post.
+			 *
+			 * @since 1.0.4
+			 *
+			 * @hook sophi_non_hierarchial_taxonomy_for_breadcrumb
+			 *
+			 * @param {string}  $taxonomy Taxonomy used for breadcrumb.
+			 * @param {WP_Post} $post     Post object.
+			 *
+			 * @return {string} Taxonomy used for breadcrumb..
+			 */
+			$taxonomy = apply_filters( 'sophi_non_hierarchial_taxonomy_for_breadcrumb', $non_hierarchial_taxonomies[0], $post );
+			$terms    = get_the_terms( $post, $taxonomy );
 
 			if ( count( $terms ) > 0 ) {
 				return $terms[0]->slug;

--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -61,11 +61,28 @@ function get_post_breadcrumb( $post ) {
 	// If the current post isn't hierarchical, we use taxonomy.
 	$taxonomies = array_filter(
 		get_object_taxonomies( $post ),
-		'is_taxonomy_hierarchical'
+		function( $taxonomy ) {
+			$taxonomy_object = get_taxonomy( $taxonomy );
+			return $taxonomy_object->hierarchical && $taxonomy_object->public && $taxonomy_object->publicly_queryable;
+		}
 	);
 
 	if ( count( $taxonomies ) > 0 ) {
-		$terms = get_the_terms( $post, $taxonomies[0] );
+		/**
+		 * Filter the taxonomy to use to create breadcrumb. Default to the first public and hierarchial taxonomy
+		 * attached to the post.
+		 *
+		 * @since 1.0.4
+		 *
+		 * @hook sophi_taxonomy_for_breadcrumb
+		 *
+		 * @param {string}  $taxonomy Taxonomy used for breadcrumb.
+		 * @param {WP_Post} $post     Post object.
+		 *
+		 * @return {string} Taxonomy used for breadcrumb..
+		 */
+		$taxonomy = apply_filters( 'sophi_taxonomy_for_breadcrumb', $taxonomies[0], $post );
+		$terms    = get_the_terms( $post, $taxonomy );
 
 		if ( count( $terms ) > 0 ) {
 			return get_term_breadcrumb( $terms[0] );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes the compatibility issue for sites using Co-Authors Plus and prevents similar issues for other plugins. With this PR, only public taxonomy is used to build the breadcrumb.

For special needs, the final taxonomy is now filterable so developers can control which taxonomy to use.

Thank @barryceelen for the suggestion!

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
Fixed: only use public taxonomies to build post breadcrumb.