### PR TITLE
Fix: Quick Edit compatibility with Yoast 

### DIFF
--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -79,6 +79,16 @@ function track_event( $new_status, $old_status, $post ) {
 	}
 
 	if ( class_exists( 'WPSEO_Meta' ) ) {
+		// Detech if the current request comes from Quick Edit.
+		if (
+			! empty( $_POST['_inline_edit'] )
+			&& wp_verify_nonce( $_POST['_inline_edit'], 'inlineeditnonce' )
+			&& ! empty( $_POST['action'] )
+			&& 'inline-save' === $_POST['action']
+		) {
+			return send_track_event( $tracker, $post, $action );
+		}
+
 		$pending_action = get_transient( 'sophi_content_sync_pending_' . $post->ID );
 
 		// Only set temporary action when publishing content

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -79,7 +79,7 @@ function track_event( $new_status, $old_status, $post ) {
 	}
 
 	if ( class_exists( 'WPSEO_Meta' ) ) {
-		// Detech if the current request comes from Quick Edit.
+		// Detect if the current request comes from Quick Edit.
 		if (
 			! empty( $_POST['_inline_edit'] )
 			&& wp_verify_nonce( $_POST['_inline_edit'], 'inlineeditnonce' )


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
We have another compatibility issue with Yoast. In #107, we fixed the publishing issue when Yoast SEO is activated but also introduced another issue, update events through Quick Edit aren't sent to Sophi. This PR fixes this issue by detecting events through Quick Edit.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
Fixed: update events via Quick Edit are not being sent to Sophi when Yoast SEO is activated.