### PR TITLE
Add cache to the curated posts retrieved

### DIFF
--- a/includes/blocks/site-automation-block/register.php
+++ b/includes/blocks/site-automation-block/register.php
@@ -42,7 +42,9 @@ function render_block_callback( $attributes, $content, $block ) {
 
 	$curated_posts_transient_key = 'sophi_curated_posts_' . $page_name . '_' . $widget_name;
 
-	if ( false === ( $curated_posts = get_transient( $curated_posts_transient_key ) ) ) {
+	$curated_posts = get_transient( $curated_posts_transient_key );
+
+	if ( false === $curated_posts ) {
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
 		$curated_posts = get_posts(
 			[

--- a/includes/blocks/site-automation-block/register.php
+++ b/includes/blocks/site-automation-block/register.php
@@ -40,17 +40,22 @@ function render_block_callback( $attributes, $content, $block ) {
 	$page_name   = sanitize_title( $attributes['pageName'] );
 	$widget_name = sanitize_title( $attributes['widgetName'] );
 
-	// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
-	$curated_posts = get_posts(
-		[
-			'sophi_curated_page'   => $page_name,
-			'sophi_curated_widget' => $widget_name,
-			'suppress_filters'     => false,
-		]
-	);
+	$curated_posts_transient_key = 'sophi_curated_posts_' . $page_name . '_' . $widget_name;
 
-	if ( empty( $curated_posts ) ) {
-		return '';
+	if ( false === ( $curated_posts = get_transient( $curated_posts_transient_key ) ) ) {
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
+		$curated_posts = get_posts(
+			[
+				'sophi_curated_page'   => $page_name,
+				'sophi_curated_widget' => $widget_name,
+			]
+		);
+
+		if ( empty( $curated_posts ) ) {
+			return '';
+		}
+
+		set_transient( $curated_posts_transient_key, $curated_posts, 5 * MINUTE_IN_SECONDS );
 	}
 
 	ob_start();


### PR DESCRIPTION
### Description of the Change

This PR adds a transient to hold the curated posts retrieved. The key used in the transient relies on page and widget names. Other than that, it fixes the duplication content issue when two blocks are added to the same page.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/globeandmail/sophi-for-wordpress/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Changed the way we cached the curated posts retrieved.
