### PR TITLE
SIT-3022: fix/ Rogers-crossposting: update utils.php with client code for cross posting

### DIFF
--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -328,6 +328,74 @@ function get_number_of_embedded_images( $post_content ) {
 	return false;
 }
 
+/**
+ * Build the category tree
+ *
+ * This function returns an array with the following structure
+ *
+ * [
+ *  	[parent_term_id] => [
+ * 			[children] => [
+ * 				[child_term_id] => [
+ * 					[name]     => 'child_term_name',
+ * 					[children] => [
+ * 						[...]
+ * 					]
+ * 				]
+ * 			]
+ * 		]
+ * 		[...]
+ * ]
+ *
+ * @param array   $categories_tree  Array used to hold the categories (passed by reference)
+ * @param WP_Term $child_category   Child category
+ * @param array   $ancestors        The ancestors ids of child category from highest to lowest in the hierarchy
+ * @param integer $key              Position in the hierarchy of ancestors
+ * @param integer $depth_level      Check how depth we are to avoid an infinite loop
+ * @return void
+ */
+function build_category_tree( &$categories_tree, $child_category, $ancestors, $key = 0, $depth_level = 0 ) {
+	$count = count( $ancestors );
+
+	if ( $key < $count && 200 > $depth_level ) {
+		// If the category is not on the category tree, add it.
+		if ( ! array_key_exists( $ancestors[ $key ], $categories_tree ) ) {
+			$categories_tree[ $ancestors[ $key ] ]['children'] = [];
+		}
+
+		// Fill with child category name
+		if ( $ancestors[ $key ] === $child_category->parent ) {
+			$categories_tree[ $ancestors[ $key ] ]['children'][ $child_category->term_id ]['name'] = $child_category->name;
+		}
+
+		// Go to the next level of hierarchy
+		build_category_tree( $categories_tree[ $ancestors[ $key ] ]['children'], $child_category, $ancestors, $key + 1, $depth_level + 1 );
+	}
+
+}
+
+/**
+ * Return the categories in a flat array preserving the hierarchical order
+ *
+ * @param array $categories_tree The categories tree with the structure used by build_category_tree().
+ * @return array
+ */
+function get_categories_hierarchical( $categories_tree ) {
+	global $arr;
+
+	foreach ( $categories_tree as $category ) {
+		if ( ! empty( $category['name'] ) ) {
+			$arr[] = $category['name'];
+		}
+
+		if ( ! empty( $category['children'] ) ) {
+			get_categories_hierarchical( $category['children'] );
+		}
+
+	}
+
+	return $arr;
+}
 
 /**
  * Get the post categories preserving the hierarchical order
@@ -396,75 +464,6 @@ function get_post_categories( $post_id ) {
 		if ( $categories_termid_name_parent === $cached_categories['term_id_name_parent_serialized'] ) {
 			return $cached_categories['formatted'];
 		}
-	}
-
-	/**
-	 * Build the category tree
-	 *
-	 * This function returns an array with the following structure
-	 *
-	 * [
-	 *  	[parent_term_id] => [
-	 * 			[children] => [
-	 * 				[child_term_id] => [
-	 * 					[name]     => 'child_term_name',
-	 * 					[children] => [
-	 * 						[...]
-	 * 					]
-	 * 				]
-	 * 			]
-	 * 		]
-	 * 		[...]
-	 * ]
-	 *
-	 * @param array   $categories_tree  Array used to hold the categories (passed by reference)
-	 * @param WP_Term $child_category   Child category
-	 * @param array   $ancestors        The ancestors ids of child category from highest to lowest in the hierarchy
-	 * @param integer $key              Position in the hierarchy of ancestors
-	 * @param integer $depth_level      Check how depth we are to avoid an infinite loop
-	 * @return void
-	 */
-	function build_category_tree( &$categories_tree, $child_category, $ancestors, $key = 0, $depth_level = 0 ) {
-		$count = count( $ancestors );
-
-		if ( $key < $count && 200 > $depth_level ) {
-			// If the category is not on the category tree, add it.
-			if ( ! array_key_exists( $ancestors[ $key ], $categories_tree ) ) {
-				$categories_tree[ $ancestors[ $key ] ]['children'] = [];
-			}
-
-			// Fill with child category name
-			if ( $ancestors[ $key ] === $child_category->parent ) {
-				$categories_tree[ $ancestors[ $key ] ]['children'][ $child_category->term_id ]['name'] = $child_category->name;
-			}
-
-			// Go to the next level of hierarchy
-			build_category_tree( $categories_tree[ $ancestors[ $key ] ]['children'], $child_category, $ancestors, $key + 1, $depth_level + 1 );
-		}
-
-	}
-
-	/**
-	 * Return the categories in a flat array preserving the hierarchical order
-	 *
-	 * @param array $categories_tree The categories tree with the structure used by build_category_tree().
-	 * @return array
-	 */
-	function get_categories_hierarchical( $categories_tree ) {
-		global $arr;
-
-		foreach ( $categories_tree as $category ) {
-			if ( ! empty( $category['name'] ) ) {
-				$arr[] = $category['name'];
-			}
-
-			if ( ! empty( $category['children'] ) ) {
-				get_categories_hierarchical( $category['children'] );
-			}
-
-		}
-
-		return $arr;
 	}
 
 	$root_categories     = [];


### PR DESCRIPTION


### Description of the Change
Please inspect this updated code as received by client and advise us if there will be any breaking changes introduced. 

Notes from client: 
It's an issue if the function is called multiple times, the functions in those lines are in a function, which declares those functions every time the function is called.
Removing those functions from the containers functions fixes the problem.
This is a problem if you do multiple post inserts in the same script, which is the case on News because we crossposts some posts through our different sites.

The issue as actually happening because we do multiple wp_insert_posts in the same PHP script. Maybe I misspoke the right term, but basically, since we have a loop that create multiple posts, in one go, and that this function called get_post_categories has function declarations in it, there is a Fatal error in PHP since you can't declare two functions with the same name.
We crosspost stories from one site to multiple sites when the story is relevant for the other sites, most likely when the story is national.
The crossposting functionality duplicate the post on another site, and links them, so when the "parent" article gets an update, the "children" articles get the same updates
Personally, I would suggest not having named functions or not have function declarations in a function.

