### PR TITLE
add caveat to README about the usage of get_posts instead of WP_Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ Note that you need to add `data-sophi-feature=<widget_name>` to the wrapper div 
 ```
 
 #### Caveats
-While the above query integration works just fine, it has been observed that on VIP infrastructures, `WP_Query` returns latest posts instead of the posts curated by Sophi. A workaround for this is to use [get_posts](https://developer.wordpress.org/reference/functions/get_posts/) instead.
+
+While the above query integration works just fine, it has been observed on [WordPress VIP](https://wpvip.com/) infrastructure that `WP_Query` may return latest posts instead of the posts curated by Sophi. A workaround for this is to use [`get_posts()`](https://developer.wordpress.org/reference/functions/get_posts/) instead.
 
 ### Post content type
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Note that you need to add `data-sophi-feature=<widget_name>` to the wrapper div 
 </div>
 ```
 
+#### Caveats
+While the above query integration works just fine, it has been observed that on VIP infrastructures, `WP_Query` returns latest posts instead of the posts curated by Sophi. A workaround for this is to use [get_posts](https://developer.wordpress.org/reference/functions/get_posts/) instead.
+
 ### Post content type
 
 By default, Sophi for WordPress uses post format as the content type. This plugin uses `content_type` internally to distinguish between WordPress post type and Sophi type.

--- a/README.md
+++ b/README.md
@@ -114,11 +114,10 @@ Note that you need to add `data-sophi-feature=<widget_name>` to the wrapper div 
 ```
 
 #### Caveats
-While the above query integration works just fine, it has been observed that on VIP infrastructures, `WP_Query` returns latest posts instead of the posts curated by Sophi. A workaround for this is to use [get_posts](https://developer.wordpress.org/reference/functions/get_posts/) instead. Also remember to whitelist `get_posts` by adding the following inline comment so that PHPCS doesn't throw a warning:
+
+While the above query integration works just fine, it has been observed on on [WordPress VIP](https://wpvip.com/) infrastructure that `WP_Query` may return latest posts instead of the posts curated by Sophi. A workaround for this is to use [`get_posts()`](https://developer.wordpress.org/reference/functions/get_posts/) instead and as good practice to add a comment explaining the usage of it so that developers new to it don't swap it for `WP_Query`. Also remember to whitelist `get_posts` by adding the following inline comment so that PHPCS doesn't throw a warning:
 
 `phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts`
-
-In addition to using `get_posts`, it would be good practice to add a comment explaining the usage of it so that developers new to it don't swap it for `WP_Query`.
 
 ### Post content type
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note that you need to add `data-sophi-feature=<widget_name>` to the wrapper div 
 
 #### Caveats
 
-While the above query integration works just fine, it has been observed on on [WordPress VIP](https://wpvip.com/) infrastructure that `WP_Query` may return latest posts instead of the posts curated by Sophi. A workaround for this is to use [`get_posts()`](https://developer.wordpress.org/reference/functions/get_posts/) instead and as good practice to add a comment explaining the usage of it so that developers new to it don't swap it for `WP_Query`. Also remember to whitelist `get_posts` by adding the following inline comment so that PHPCS doesn't throw a warning:
+While the above query integration works just fine, it has been observed on [WordPress VIP](https://wpvip.com/) infrastructure that `WP_Query` may return latest posts instead of the posts curated by Sophi. A workaround for this is to use [`get_posts()`](https://developer.wordpress.org/reference/functions/get_posts/) instead and as good practice to add a comment explaining the usage of it so that developers new to it don't swap it for `WP_Query`. Also remember to whitelist `get_posts` by adding the following inline comment so that PHPCS doesn't throw a warning:
 
 `phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts`
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ Note that you need to add `data-sophi-feature=<widget_name>` to the wrapper div 
 ```
 
 #### Caveats
-While the above query integration works just fine, it has been observed that on VIP infrastructures, `WP_Query` returns latest posts instead of the posts curated by Sophi. A workaround for this is to use [get_posts](https://developer.wordpress.org/reference/functions/get_posts/) instead.
+While the above query integration works just fine, it has been observed that on VIP infrastructures, `WP_Query` returns latest posts instead of the posts curated by Sophi. A workaround for this is to use [get_posts](https://developer.wordpress.org/reference/functions/get_posts/) instead. Also remember to whitelist `get_posts` by adding the following inline comment so that PHPCS doesn't throw a warning:
+`phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts`
+
+In addition to using `get_posts`, it would be good practice to add a comment explaining the usage of it so that developers new to it don't swap it for `WP_Query`.
 
 ### Post content type
 

--- a/readme.txt
+++ b/readme.txt
@@ -95,11 +95,9 @@ Note that you need to add `data-sophi-feature=<widget_name>` to the wrapper div 
 
 == Caveats ==
 
-While the above query integration works just fine, it has been observed that on VIP infrastructures, `WP_Query` returns latest posts instead of the posts curated by Sophi. A workaround for this is to use [get_posts](https://developer.wordpress.org/reference/functions/get_posts/) instead. Also remember to whitelist `get_posts` by adding the following inline comment so that PHPCS doesn't throw a warning:
+While the above query integration works just fine, it has been observed on [WordPress VIP](https://wpvip.com/) infrastructure that `WP_Query` may return latest posts instead of the posts curated by Sophi. A workaround for this is to use [`get_posts()`](https://developer.wordpress.org/reference/functions/get_posts/) instead and as good practice to add a comment explaining the usage of it so that developers new to it don't swap it for `WP_Query`. Also remember to whitelist `get_posts` by adding the following inline comment so that PHPCS doesn't throw a warning:
 
 `phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts`
-
-In addition to using `get_posts`, it would be good practice to add a comment explaining the usage of it so that developers new to it don't swap it for `WP_Query`.
 
 = Post content type =
 

--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,12 @@ Note that you need to add `data-sophi-feature=<widget_name>` to the wrapper div 
 </div>
 `
 
+== Caveats ==
+While the above query integration works just fine, it has been observed that on VIP infrastructures, `WP_Query` returns latest posts instead of the posts curated by Sophi. A workaround for this is to use [get_posts](https://developer.wordpress.org/reference/functions/get_posts/) instead. Also remember to whitelist `get_posts` by adding the following inline comment so that PHPCS doesn't throw a warning:
+`phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts`
+
+In addition to using `get_posts`, it would be good practice to add a comment explaining the usage of it so that developers new to it don't swap it for `WP_Query`.
+
 = Post content type =
 
 By default, Sophi for WordPress uses post format as the content type. This plugin uses `content_type` internally to distinguish between WordPress post type and Sophi type.


### PR DESCRIPTION

### Description of the Change

Added a caveat surrounding the usage of WP_Query on a VIP environment.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry
> doc: update README about the usage of WP_Query

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @Sidsector9 
