### PR TITLE
Add hooks to Sophi requests

### DIFF
--- a/includes/classes/SiteAutomation/Auth.php
+++ b/includes/classes/SiteAutomation/Auth.php
@@ -64,19 +64,26 @@ class Auth {
 	 * @return array|\WP_Error
 	 */
 	public function request_access_token( $client_id, $client_secret ) {
-		$body    = [
+		$body = [
 			'client_id'     => $client_id,
 			'client_secret' => $client_secret,
 			'audience'      => $this->get_audience(),
 			'grant_type'    => 'client_credentials',
 		];
-		$request = wp_remote_post(
-			$this->get_auth_url(),
-			[
-				'headers' => [ 'Content-Type' => 'application/json' ],
-				'body'    => wp_json_encode( $body ),
-			]
-		);
+		$args = [
+			'headers' => [ 'Content-Type' => 'application/json' ],
+			'body'    => wp_json_encode( $body ),
+		];
+
+		$auth_url = $this->get_auth_url();
+
+		/** This filter is documented in includes/classes/SiteAutomation/Request.php */
+		$args = apply_filters( 'sophi_request_args', $args, $auth_url );
+
+		$request = wp_remote_post( $auth_url, $args );
+
+		/** This filter is documented in includes/classes/SiteAutomation/Request.php */
+		$request = apply_filters( 'sophi_request_result', $request, $args, $this->api_url );
 
 		if ( is_wp_error( $request ) ) {
 			return $request;

--- a/includes/classes/SiteAutomation/Request.php
+++ b/includes/classes/SiteAutomation/Request.php
@@ -226,7 +226,7 @@ class Request {
 		/**
 		 * Filters a Sophi HTTP request immediately after the response is received.
 		 *
-		 * @since 2.9.0
+		 * @since 1.0.14
 		 *
 		 * @param array|WP_Error  $response HTTP response.
 		 * @param array           $args     HTTP request arguments.

--- a/includes/classes/SiteAutomation/Request.php
+++ b/includes/classes/SiteAutomation/Request.php
@@ -206,12 +206,33 @@ class Request {
 			],
 		];
 
+		/**
+		 * Filters the arguments used in Sophi HTTP request.
+		 *
+		 * @since 1.0.14
+		 *
+		 * @param array   $args An array of HTTP request arguments.
+		 * @param string  $url  The request URL.
+		 */
+		$args = apply_filters( 'sophi_request_args', $args, $this->api_url );
+
 		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
 			$request = vip_safe_wp_remote_get( $this->api_url, '', 3, $timeout, 20, $args );
 		} else {
 			$args['timeout'] = $timeout;
 			$request         = wp_remote_get( $this->api_url, $args ); // phpcs:ignore
 		}
+
+		/**
+		 * Filters a Sophi HTTP request immediately after the response is received.
+		 *
+		 * @since 2.9.0
+		 *
+		 * @param array|WP_Error  $response HTTP response.
+		 * @param array           $args     HTTP request arguments.
+		 * @param string          $url      The request URL.
+		 */
+		$request = apply_filters( 'sophi_request_result', $request, $args, $this->api_url );
 
 		if ( is_wp_error( $request ) ) {
 			return $request;

--- a/includes/classes/SiteAutomation/Request.php
+++ b/includes/classes/SiteAutomation/Request.php
@@ -210,9 +210,12 @@ class Request {
 		 * Filters the arguments used in Sophi HTTP request.
 		 *
 		 * @since 1.0.14
+		 * @hook sophi_request_args
 		 *
-		 * @param array   $args An array of HTTP request arguments.
-		 * @param string  $url  The request URL.
+		 * @param {array}   $args HTTP request arguments.
+		 * @param {string}  $url  The request URL.
+		 * 
+		 * @return {array} HTTP request arguments.
 		 */
 		$args = apply_filters( 'sophi_request_args', $args, $this->api_url );
 
@@ -227,10 +230,13 @@ class Request {
 		 * Filters a Sophi HTTP request immediately after the response is received.
 		 *
 		 * @since 1.0.14
+		 * @hook sophi_request_result
 		 *
-		 * @param array|WP_Error  $response HTTP response.
-		 * @param array           $args     HTTP request arguments.
-		 * @param string          $url      The request URL.
+		 * @param {array|WP_Error}  $request Result of HTTP request.
+		 * @param {array}           $args     HTTP request arguments.
+		 * @param {string}          $url      The request URL.
+		 * 
+		 * @return {array|WP_Error} Result of HTTP request.
 		 */
 		$request = apply_filters( 'sophi_request_result', $request, $args, $this->api_url );
 

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -194,8 +194,17 @@ function init_tracker() {
 		);
 	}
 
+	/**
+	 * Turns on emitter debug
+	 *
+	 * @since 1.0.14
+	 * 
+	 * @param bool $debug Debug is active.
+	 */
+	$debug = apply_filters( 'sophi_tracker_emitter_debug', false );
+
 	$app_id  = sprintf( '%s:cms', $tracker_client_id );
-	$emitter = new SyncEmitter( $collector_url, 'https', 'POST', 1, false );
+	$emitter = new SyncEmitter( $collector_url, 'https', 'POST', 1, $debug );
 	$subject = new Subject();
 	return new Tracker( $emitter, $subject, 'sophiTag', $app_id, false );
 }

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -135,11 +135,14 @@ function send_track_event( $tracker, $post, $action ) {
 	 * Filters the data used in Sophi track event request.
 	 *
 	 * @since 1.0.14
+	 * @hook sophi_tracking_data
 	 *
-	 * @param array   $data    Tracking data.
-	 * @param Tracker $tracker Tracker being used.
-	 * @param string  $url     Post object.
-	 * @param string  $action  Publishing action.
+	 * @param {array}   $data    Tracking data to send.
+	 * @param {Tracker} $tracker Tracker being used.
+	 * @param {string}  $url     Post object.
+	 * @param {string}  $action  Publishing action.
+	 * 
+	 * @return {array} Tracking data to send.
 	 */
 	$data = apply_filters_ref_array( 'sophi_tracking_data', array( $data, &$tracker, $post, $action ) );
 	$tracker->trackUnstructEvent(
@@ -162,11 +165,12 @@ function send_track_event( $tracker, $post, $action ) {
 	 * Fires after tracker sends the request.
 	 *
 	 * @since 1.0.14
+	 * @hook sophi_tracking_result
 	 *
-	 * @param array   $data    Tracked data.
-	 * @param Tracker $tracker Tracker object.
-	 * @param WP_Post $post    Post object.
-	 * @param string  $action  Publishing action.
+	 * @param {array}   $data    Tracked data.
+	 * @param {Tracker} $tracker Tracker object.
+	 * @param {WP_Post} $post    Post object.
+	 * @param {string}  $action  Publishing action.
 	 */
 	do_action_ref_array( 'sophi_tracking_result', array( $data, &$tracker, $post, $action ) );
 }
@@ -195,11 +199,14 @@ function init_tracker() {
 	}
 
 	/**
-	 * Turns on emitter debug
+	 * Whether to turn on emitter debug
 	 *
 	 * @since 1.0.14
+	 * @hook sophi_tracker_emitter_debug
+	 *
+	 * @param {bool} $debug Debug is active.
 	 * 
-	 * @param bool $debug Debug is active.
+	 * @return {bool} Whether to turn on emitter debug.
 	 */
 	$debug = apply_filters( 'sophi_tracker_emitter_debug', false );
 

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -131,6 +131,17 @@ function send_track_event( $tracker, $post, $action ) {
 		delete_transient( 'sophi_content_sync_pending_' . $post->ID );
 	}
 
+	/**
+	 * Filters the data used in Sophi track event request.
+	 *
+	 * @since 1.0.14
+	 *
+	 * @param array   $data    Tracking data.
+	 * @param Tracker $tracker Tracker being used.
+	 * @param string  $url     Post object.
+	 * @param string  $action  Publishing action.
+	 */
+	$data = apply_filters_ref_array( 'sophi_tracking_data', array( $data, &$tracker, $post, $action ) );
 	$tracker->trackUnstructEvent(
 		[
 			'schema' => 'iglu:com.sophi/content_update/jsonschema/2-0-3',
@@ -146,6 +157,18 @@ function send_track_event( $tracker, $post, $action ) {
 			],
 		]
 	);
+
+	/**
+	 * Fires after tracker sends the request.
+	 *
+	 * @since 1.0.14
+	 *
+	 * @param array   $data    Tracked data.
+	 * @param Tracker $tracker Tracker object.
+	 * @param WP_Post $post    Post object.
+	 * @param string  $action  Publishing action.
+	 */
+	do_action_ref_array( 'sophi_tracking_result', array( $data, &$tracker, $post, $action ) );
 }
 
 /**


### PR DESCRIPTION
## Description of the Change

This PR introducing new hooks to remote requests:

### Hooks for Site Automation

`sophi_request_args` **filter:**  Filters the arguments used in Sophi HTTP request.
`sophi_request_result` **filter:** Filters a Sophi HTTP request immediately after the response is received.

Used in: `SophiWP\SiteAutomation\Request::request()` and `SophiWP\SiteAutomation\Auth::request_access_token()`

### Hooks for event tracker

`sophi_tracking_data` **filter:** Filters the data used in Sophi track event request.
`sophi_tracking_result` **action:** Fires after tracker sends the request.

Since the entire `$data` array is sent to Snowplow, looks it not safe to add new attributes to the array (f.e. for debugging). That's why we add the `Snowplow\Tracker\Tracker $tracker` object as a reference in both filters.

Used in: `SophiWP\ContentSync\send_track_event()`

`sophi_tracker_emitter_debug` **filter:** Allows to enable debug mode in the emitter to save responses and analyse them later.

Used in: `SophiWP\ContentSync\init_tracker()`

<!-- Enter any applicable Issues here. Example: -->
Closes #255 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Added - Filter `sophi_request_args` filters arguments used in Sophi HTTP request.
> Added - Filter `sophi_request_result` filters a Sophi HTTP request immediately after the response is received.
> Added - Filter `sophi_tracking_data` filters the data used in Sophi track event request.
> Added - Action `sophi_tracking_result` fires after tracker sends the request.
> Added - Filter `sophi_tracker_emitter_debug` allows to enable debug mode in the tracking emitter.
### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic 
