### PR TITLE
Fixed Undefined property warning for request filter argument

### DIFF
--- a/includes/classes/SiteAutomation/Auth.php
+++ b/includes/classes/SiteAutomation/Auth.php
@@ -83,7 +83,7 @@ class Auth {
 		$request = wp_remote_post( $auth_url, $args );
 
 		/** This filter is documented in includes/classes/SiteAutomation/Request.php */
-		$request = apply_filters( 'sophi_request_result', $request, $args, $this->api_url );
+		$request = apply_filters( 'sophi_request_result', $request, $args, $auth_url );
 
 		if ( is_wp_error( $request ) ) {
 			return $request;


### PR DESCRIPTION
### Description of the Change

Recently in #257 (merged) was added a mistype, the arguments for `sophi_request_result` in Auth::request_access_token() were copied from the same filter in `Request:request()`.

That's why each time Auth:request_access_token() is called, it produce the Warning

Closes: #260

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
