### PR TITLE
Update/hookdocs trunk

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - trunk
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   release:
@@ -23,7 +26,7 @@ jobs:
         npm run build
         npm run build:docs
     - name: Deploy docs update
-      uses: maxheld83/ghpages@v0.3.0
-      env:
-        BUILD_DIR: 'docs/'
-        GH_PAT: ${{ secrets.GH_PAT }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: './docs'

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - trunk
-  pull_request:
-    branches:
-      - develop
 
 jobs:
   release:


### PR DESCRIPTION
Cherry-picked the hookdocs-related changes from `develop` into `trunk` to properly generate hookdocs coming out of the recent 1.1.0 release.