### PR TITLE
Suppress Emitter debug output and writing logs

### DIFF
--- a/includes/classes/Emitter.php
+++ b/includes/classes/Emitter.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Custom Sophi Emitter
+ *
+ * @package SophiWP
+ */
+
+namespace SophiWP;
+
+use Snowplow\Tracker\Emitters\SyncEmitter;
+
+/**
+ * Extend Snowplow Emitter and overload it's filesystem
+ * methods to disable 3rd-party debug logging
+ */
+class Emitter extends SyncEmitter {
+
+	public function makeDir( $dir ) {
+		return false;
+	}
+
+	public function openFile( $file_path ) {
+		return false;
+	}
+
+	public function closeFile( $file_path ) {
+		return false;
+	}
+
+	public function copyFile( $path_from, $path_to ) {
+		return false;
+	}
+
+	public function deleteFile( $file_path ) {
+		return false;
+	}
+
+	public function writeToFile( $file_path, $content ) {
+		return false;
+	}
+
+}

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -15,7 +15,7 @@ use SophiWP\Utils;
 
 use Snowplow\Tracker\Tracker;
 use Snowplow\Tracker\Subject;
-use Snowplow\Tracker\Emitters\SyncEmitter;
+use SophiWP\Emitter;
 
 /**
  * Default setup routine
@@ -224,7 +224,7 @@ function init_tracker() {
 	$debug = apply_filters( 'sophi_tracker_emitter_debug', false );
 
 	$app_id  = sprintf( '%s:cms', $tracker_client_id );
-	$emitter = new SyncEmitter( $collector_url, 'https', 'POST', 1, $debug );
+	$emitter = new Emitter( $collector_url, 'https', 'POST', 1, $debug );
 	$subject = new Subject();
 	return new Tracker( $emitter, $subject, 'sophiTag', $app_id, false );
 }

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -145,6 +145,15 @@ function send_track_event( $tracker, $post, $action ) {
 	 * @return {array} Tracking data to send.
 	 */
 	$data = apply_filters_ref_array( 'sophi_cms_tracking_request_data', array( $data, &$tracker, $post, $action ) );
+
+	/** This filter is documented in includes/classes/SiteAutomation/Request.php */
+	$debug = apply_filters( 'sophi_tracker_emitter_debug', false );
+
+	// Suppress stdout from Emitters in debug mode.
+	if ( true === $debug ) {
+		ob_start();
+	}
+
 	$tracker->trackUnstructEvent(
 		[
 			'schema' => 'iglu:com.sophi/content_update/jsonschema/2-0-3',
@@ -160,6 +169,10 @@ function send_track_event( $tracker, $post, $action ) {
 			],
 		]
 	);
+
+	if ( true === $debug ) {
+		ob_end_clean();
+	}
 
 	/**
 	 * Fires after tracker sends the request.

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -146,7 +146,7 @@ function send_track_event( $tracker, $post, $action ) {
 	 */
 	$data = apply_filters_ref_array( 'sophi_cms_tracking_request_data', array( $data, &$tracker, $post, $action ) );
 
-	/** This filter is documented in includes/classes/SiteAutomation/Request.php */
+	/** This filter is documented in includes/functions/content-sync.php */
 	$debug = apply_filters( 'sophi_tracker_emitter_debug', false );
 
 	// Suppress stdout from Emitters in debug mode.


### PR DESCRIPTION
### Description of the Change

Extending SyncEmitter with overloaded file methods will suppress writing log files if the vendor/snowplow/snowplow-tracker/debug is writable

Adding ob_start / ob_end_clean wrapper for $tracker->trackUnstructEvent() will suppress stdout if the directory is not writable.

Closes #271 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
