### PR TITLE
Fake success instead of failure on file operations

### DIFF
--- a/includes/classes/Emitter.php
+++ b/includes/classes/Emitter.php
@@ -16,27 +16,27 @@ use Snowplow\Tracker\Emitters\SyncEmitter;
 class Emitter extends SyncEmitter {
 
 	public function makeDir( $dir ) {
-		return false;
+		return true;
 	}
 
 	public function openFile( $file_path ) {
-		return false;
+		return true;
 	}
 
 	public function closeFile( $file_path ) {
-		return false;
+		return true;
 	}
 
 	public function copyFile( $path_from, $path_to ) {
-		return false;
+		return true;
 	}
 
 	public function deleteFile( $file_path ) {
-		return false;
+		return true;
 	}
 
 	public function writeToFile( $file_path, $content ) {
-		return false;
+		return true;
 	}
 
 }


### PR DESCRIPTION
### Description of the Change

Custom Emitter will fake success for all file operations. It will prevent SyncEmitter from doing any output with `print_r` during initialization and performing requests.

Closes #271 

### Verification Process

1. Install and activate Sophi for WordPress
2. Install and activate Debug Bar for Sophi
3. Make directory read-only at `wp-content/plugins/sophi/vendor/snowplow/snowplow-tracker`
4. Create new post/page with Sophi Block
5. Click "Update"
6. Expected to successfully save post

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
