### PR TITLE
Fix/247 a `$result` is used instead of `$request`

### DIFF
--- a/includes/classes/SiteAutomation/Auth.php
+++ b/includes/classes/SiteAutomation/Auth.php
@@ -80,27 +80,26 @@ class Auth {
 		/** This filter is documented in includes/classes/SiteAutomation/Request.php */
 		$args = apply_filters( 'sophi_request_args', $args, $auth_url );
 
-		$request = wp_remote_post( $auth_url, $args );
+		$result = wp_remote_post( $auth_url, $args );
 
 		/** This filter is documented in includes/classes/SiteAutomation/Request.php */
-		$request = apply_filters( 'sophi_request_result', $request, $args, $auth_url );
+		$result = apply_filters( 'sophi_request_result', $result, $args, $auth_url );
 
-		if ( is_wp_error( $request ) ) {
-			return $request;
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
-		if ( 401 === wp_remote_retrieve_response_code( $request ) ) {
+		if ( 401 === wp_remote_retrieve_response_code( $result ) ) {
 			return new \WP_Error( 401, __( 'Invalid credentials! Please confirm your client ID and secret then try again.', 'sophi-wp' ) );
 		}
 
-		if ( 200 !== wp_remote_retrieve_response_code( $request ) ) {
-			return new \WP_Error( $request['response']['code'], $request['response']['message'] );
+		if ( 200 !== wp_remote_retrieve_response_code( $result ) ) {
+			return new \WP_Error( $result['response']['code'], $result['response']['message'] );
 		}
 
-		$response = wp_remote_retrieve_body( $request );
-		$response = json_decode( $response, true );
+		$response = wp_remote_retrieve_body( $result );
 
-		return $response;
+		return json_decode( $response, true );
 	}
 
 	/**

--- a/includes/classes/SiteAutomation/Request.php
+++ b/includes/classes/SiteAutomation/Request.php
@@ -225,16 +225,16 @@ class Request {
 		 *
 		 * @param {array}   $args HTTP request arguments.
 		 * @param {string}  $url  The request URL.
-		 * 
+		 *
 		 * @return {array} HTTP request arguments.
 		 */
 		$args = apply_filters( 'sophi_request_args', $args, $this->api_url );
 
 		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
-			$request = vip_safe_wp_remote_get( $this->api_url, '', 3, $timeout, 20, $args );
+			$result = vip_safe_wp_remote_get( $this->api_url, '', 3, $timeout, 20, $args );
 		} else {
 			$args['timeout'] = $timeout;
-			$request         = wp_remote_get( $this->api_url, $args ); // phpcs:ignore
+			$result          = wp_remote_get( $this->api_url, $args ); // phpcs:ignore
 		}
 
 		/**
@@ -243,23 +243,23 @@ class Request {
 		 * @since 1.0.14
 		 * @hook sophi_request_result
 		 *
-		 * @param {array|WP_Error}  $request Result of HTTP request.
+		 * @param {array|WP_Error}  $result Result of HTTP request.
 		 * @param {array}           $args     HTTP request arguments.
 		 * @param {string}          $url      The request URL.
-		 * 
+		 *
 		 * @return {array|WP_Error} Result of HTTP request.
 		 */
-		$request = apply_filters( 'sophi_request_result', $request, $args, $this->api_url );
+		$result = apply_filters( 'sophi_request_result', $result, $args, $this->api_url );
 
-		if ( is_wp_error( $request ) ) {
-			return $request;
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
-		if ( wp_remote_retrieve_response_code( $request ) !== 200 ) {
-			return new \WP_Error( wp_remote_retrieve_response_code( $request ), $request['response']['message'] );
+		if ( wp_remote_retrieve_response_code( $result ) !== 200 ) {
+			return new \WP_Error( wp_remote_retrieve_response_code( $result ), $result['response']['message'] );
 		}
 
-		return json_decode( wp_remote_retrieve_body( $request ), true );
+		return json_decode( wp_remote_retrieve_body( $result ), true );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

This PR simply changes the variable names.

<!-- Enter any applicable Issues here. Example: -->
Closes #247

### Alternate Designs

n/a

### Possible Drawbacks

https://github.com/globeandmail/sophi-for-wordpress/issues/247#issuecomment-1125081989

### Verification Process

This is just a variable name change, does not tweak any logic, though, a quick test of the plugin functionalities would be great.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Changed - `$result` is used instead of `$request` to store return value of the `sophi_request_result` filter.