### PR TITLE
update `sectionNames` to be same as `allSections` in content-sync.php

### DIFF
--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -272,7 +272,7 @@ function get_post_data( $post ) {
 		'plainText'           => wp_strip_all_tags( $content ),
 		'size'                => str_word_count( wp_strip_all_tags( $content ) ),
 		'allSections'         => Utils\get_post_categories_paths( $post->ID ),
-		'sectionNames'        => Utils\get_post_categories( $post->ID ),
+		'sectionNames'        => Utils\get_post_categories_paths( $post->ID ),
 		'modifiedAt'          => gmdate( \DateTime::RFC3339, strtotime( $post->post_modified_gmt ) ),
 		'tags'                => Utils\get_post_tags( $post ),
 		'url'                 => $permalink,


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Somewhere between versions 1.0.5 and 1.1.1 we updated both `sectionNames` and `allSections` fields in different requests, but somehow did not end up in the current ideal state where they're sending the literal same data.  In testing with Vijay Jayaseelan and Arijit Paul today (sorry, I don't have their GitHub handles to @mention) we determined that the individual category names from `allSections` is the expected data for Sophi and not the category paths from `sectionNames`.  So this PR updates the `sectionNames` field to have the individual category names like `allSections`.

Note that once this change is merged into `develop` and tested on a test site, we'll want to get this into a release so it can be confirmed and then make the final change in #141 to close out that issue.

<!-- Enter any applicable Issues here. Example: -->
Relates to #301 and #141.

### Alternate Designs

n/a

### Possible Drawbacks

none identified

### Verification Process

Check the content sync data sent to Sophi and see that it sends the same data for `sectionNames` and `allSections` and that its the individual categories and not the category paths.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
> Changed - `sectionNames` and `allSections` in `content-sync.php` both contain individual categories from posts

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul, Vijay Jayaseelan.