### PR TITLE
bump content_update schema from 2-0-3 to 2-0-5

### DIFF
--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -157,7 +157,7 @@ function send_track_event( $tracker, $post, $action ) {
 
 	$tracker->trackUnstructEvent(
 		[
-			'schema' => 'iglu:com.sophi/content_update/jsonschema/2-0-3',
+			'schema' => 'iglu:com.sophi/content_update/jsonschema/2-0-5',
 			'data'   => $data,
 		],
 		[


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Updates the `content_schema` used with Sophi from version 2-0-3 to 2-0-5 to allow for sending across `mediaIds` via a plugin extension (as this PR does not, intentionally, add programmatic support for that within the plugin).

<!-- Enter any applicable Issues here. Example: -->
Closes #321.

### Alternate Designs

n/a

### Possible Drawbacks

none identified

### Verification Process

Testing to be done post-merge in sample client staging environment.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Changed - Bump `content_update` schema from 2-0-3 to 2-0-5.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul, @vjayaseelan90, @YMufleh.
