### PR TITLE
try: PHP compat test with phpcompatibility-dev

### DIFF
--- a/.github/workflows/php-compatibility-dev.yml
+++ b/.github/workflows/php-compatibility-dev.yml
@@ -1,0 +1,37 @@
+name: PHP Compatibility
+
+on:
+  push:
+    branches:
+      - develop
+      - trunk
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  php-compatibility:
+    name: PHP minimum 8.0
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+              composer g require --dev phpcompatibility/phpcompatibility-wp:"*"
+              composer g config minimum-stability dev
+              composer g require --dev phpcompatibility/phpcompatibility-wp
+              composer g require --dev phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
+
+      - name: Run PHP Compatibility
+        run: vendor/bin/phpcs sophi.php includes/ --standard=PHPCompatibilityWP --severity=1 --runtime-set testVersion 8.0- --extensions=php

--- a/.github/workflows/php-compatibility-dev.yml
+++ b/.github/workflows/php-compatibility-dev.yml
@@ -1,4 +1,4 @@
-name: PHP Compatibility
+name: PHP Compatibility-dev for 8.0
 
 on:
   push:
@@ -28,10 +28,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+              composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
               composer g require --dev phpcompatibility/phpcompatibility-wp:"*"
               composer g config minimum-stability dev
               composer g require --dev phpcompatibility/phpcompatibility-wp
               composer g require --dev phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
 
       - name: Run PHP Compatibility
-        run: vendor/bin/phpcs sophi.php includes/ --standard=PHPCompatibilityWP --severity=1 --runtime-set testVersion 8.0- --extensions=php
+        run: ~/.composer/vendor/bin/phpcs sophi.php includes/ --standard=PHPCompatibilityWP --severity=1 --runtime-set testVersion 8.0- --extensions=php


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

So we already have a PHP Compatibility action in place that tests for violations on PHP 8.0.

What this PR does is does the same but uses PHPCompatibility's dev branch . This is to ensure we are testing for violations with the latest changes. This is temporary until version 10.0.0 is released. Once released we can delete this and move these  to the already existing PHP Compatibility action.

This action specifically runs on [PHP 7.4 as recommended here](https://docs.wpvip.com/how-tos/code-scanning-for-php-upgrade/#Upcoming-releases-of-PHPCompatibility).


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Security - Added latest PHPCompatibility checks for PHP 8.0

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @Sidsector9 
