### PR TITLE
Prevent tracking a duplicate event

### DIFF
--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -331,12 +331,12 @@ function maybe_skip_track_event( $data ) {
 
 	$transient_hash = substr( wp_hash( wp_json_encode( $data ) ), 0, 8 );
 	$transient_name = 'sophi_tracking_request_' . $transient_hash;
-	$tracked_data   = get_transient( $transient_name );
 
-	if ( isset( $_GET['meta-box-loader'] ) && $_GET['meta-box-loader'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	if ( isset( $_GET['meta-box-loader'] ) && $_GET['meta-box-loader'] ) {
 		// Skip if metabox is reloading.
 		$skip = true;
-	} elseif ( $tracked_data === $data ) {
+	} elseif ( get_transient( $transient_name ) === $data ) {
 		// Skip duplicated track within last 10 seconds.
 		$skip = true;
 	} else {

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -317,7 +317,7 @@ function get_post_data( $post ) {
 }
 
 /**
- * Check if the current data has been already tracked recently ans should be skipped.
+ * Check if the current data has been already tracked recently and should be skipped.
  *
  * @since 1.3.0
  *

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -333,9 +333,11 @@ function maybe_skip_track_event( $data ) {
 	$transient_name = 'sophi_tracking_request_' . $transient_hash;
 	$tracked_data   = get_transient( $transient_name );
 
-	// Check if the object was already tracked within last 10 seconds.
-	if ( $tracked_data === $data ) {
-		// Skip duplicated track.
+	if ( isset( $_GET['meta-box-loader'] ) && $_GET['meta-box-loader'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// Skip if metabox is reloading.
+		$skip = true;
+	} elseif ( $tracked_data === $data ) {
+		// Skip duplicated track within last 10 seconds.
 		$skip = true;
 	} else {
 		/**

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -150,6 +150,10 @@ function send_track_event( $tracker, $post, $action ) {
 	/** This filter is documented in includes/functions/content-sync.php */
 	$debug = apply_filters( 'sophi_tracker_emitter_debug', false );
 
+	if ( maybe_skip_track_event( $data ) ) {
+		return;
+	}
+
 	// Suppress stdout from Emitters in debug mode.
 	if ( true === $debug ) {
 		ob_start();
@@ -310,4 +314,50 @@ function get_post_data( $post ) {
 	 * @return {array} Formatted post data.
 	 */
 	return apply_filters( 'sophi_post_data', $data );
+}
+
+function maybe_skip_track_event( $data ) {
+	// Ignore modifiedAt.
+	unset( $data['modifiedAt'] );
+
+	$transient_hash = substr( wp_hash( wp_json_encode( $data ) ), 0, 8 );
+	$transient_name = 'sophi_tracking_request_' . $transient_hash;
+	$tracked_data   = get_transient( $transient_name );
+
+	// Check if the object was already tracked within last 10 seconds.
+	if ( $tracked_data === $data ) {
+		// Skip duplicated track.
+		$skip = true;
+	} else {
+		/**
+		 * Filters the TTL of duplicated request.
+		 *
+		 * @since 1.3.0
+		 * @hook sophi_cms_track_duplicate_ttl
+		 *
+		 * @param {int}   $ttl  TTL of duplicated request.
+		 * @param {array} $data Data to track.
+		 *
+		 * @return {int}
+		 */
+		$ttl = apply_filters( 'sophi_cms_track_duplicate_ttl', 10, $data );
+
+		// Remember the current tracking object.
+		set_transient( $transient_name, $data, $ttl );
+
+		$skip = false;
+	}
+
+	/**
+	 * Allow to override the flag of tracking event should be skipped.
+	 *
+	 * @since 1.3.0
+	 * @hook sophi_skip_track_event
+	 *
+	 * @param {boolean} $skip Whether to skip tracking.
+	 * @param {array}   $data Data to track.
+	 * 
+	 * @return {boolean}
+	 */
+	return apply_filters( 'sophi_skip_track_event', $skip, $data );
 }

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -316,6 +316,15 @@ function get_post_data( $post ) {
 	return apply_filters( 'sophi_post_data', $data );
 }
 
+/**
+ * Check if the current data has been already tracked recently ans should be skipped.
+ *
+ * @since 1.3.0
+ *
+ * @param array $data Data being tracked
+ *
+ * @return boolean
+ */
 function maybe_skip_track_event( $data ) {
 	// Ignore modifiedAt.
 	unset( $data['modifiedAt'] );

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -329,7 +329,7 @@ function maybe_skip_track_event( $data ) {
 	// Ignore modifiedAt.
 	unset( $data['modifiedAt'] );
 
-	$transient_hash = substr( wp_hash( wp_json_encode( $data ) ), 0, 8 );
+	$transient_hash = substr( md5( wp_json_encode( $data ) ), 0, 8 );
 	$transient_name = 'sophi_tracking_request_' . $transient_hash;
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/tests/phpunit/test-tools/SkipTracking_Tests.php
+++ b/tests/phpunit/test-tools/SkipTracking_Tests.php
@@ -20,6 +20,7 @@ class SkipTracking_Tests extends Base\TestCase {
 
 		\WP_Mock::userFunction( 'wp_json_encode' )->andReturnUsing(
 			function( $data ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Mocking the function
 				return json_encode( $data );
 			}
 		);

--- a/tests/phpunit/test-tools/SkipTracking_Tests.php
+++ b/tests/phpunit/test-tools/SkipTracking_Tests.php
@@ -1,0 +1,87 @@
+<?php
+namespace SophiWP\ContentSync;
+
+use SophiWP as Base;
+
+class SkipTracking_Tests extends Base\TestCase {
+
+	protected $testFiles = array(
+		'functions/content-sync.php',
+	);
+
+	public function setUp() :void {
+		\WP_Mock::setUp();
+
+		\WP_Mock::userFunction( 'wp_hash' )->andReturnUsing(
+			function( $data ) {
+				return md5( $data );
+			}
+		);
+
+		\WP_Mock::userFunction( 'wp_json_encode' )->andReturnUsing(
+			function( $data ) {
+				return json_encode( $data );
+			}
+		);
+
+		parent::setUp();
+	}
+
+	public function tearDown() :void {
+		\WP_Mock::tearDown();
+	}
+
+	/**
+	 * Test Maybe Skip logic
+	 *
+	 * @covers \SophiWP\ContentSync\maybe_skip_track_event
+	 * @dataProvider data_provider_for_test_maybe_skip
+	 */
+	public function test_maybe_skip( $data, $get_transient, $set_transient, $should_skip ) {
+
+		\WP_Mock::userFunction( 'wp_hash' )->andReturn( '' );
+		\WP_Mock::userFunction( 'wp_json_encode' )->andReturn( '' );
+		\WP_Mock::userFunction( 'get_transient' )->andReturn( $get_transient );
+
+		if ( $set_transient ) {
+			\WP_Mock::userFunction( 'set_transient' )->with( 'sophi_tracking_request_', $set_transient, 10 );
+		}
+
+		$this->assertSame( $should_skip, maybe_skip_track_event( $data ) );
+	}
+
+	public function data_provider_for_test_maybe_skip() {
+		return array(
+			'Should ignore modifiedAt argument'         => array(
+				'data'          => array( 'a' => 'b', 'modifiedAt' => 'c' ),
+				'get_transient' => false,
+				'set_transient' => array( 'a' => 'b' ),
+				'should_skip'   => false,
+			),
+			'Should skip when transient exists'         => array(
+				'data'          => array( 'a' => 'b' ),
+				'get_transient' => array( 'a' => 'b' ),
+				'set_transient' => false,
+				'should_skip'   => true,
+			),
+			'Should not skip when transient is not set' => array(
+				'data'          => array( 'a' => 'b' ),
+				'get_transient' => false,
+				'set_transient' => array( 'a' => 'b' ),
+				'should_skip'   => false,
+			),
+			'Should not skip when previous request was different' => array(
+				'data'          => array( 'a' => 'b' ),
+				'get_transient' => array( 'c' => 'd' ),
+				'set_transient' => array( 'a' => 'b' ),
+				'should_skip'   => false,
+			),
+		);
+	}
+	/**
+	 * Test get number of embedded images
+	 */
+	public function test_should_pass_untracked_event() {
+		$this->assertTrue( true );
+	}
+}

--- a/tests/phpunit/test-tools/SkipTracking_Tests.php
+++ b/tests/phpunit/test-tools/SkipTracking_Tests.php
@@ -54,7 +54,10 @@ class SkipTracking_Tests extends Base\TestCase {
 	public function data_provider_for_test_maybe_skip() {
 		return array(
 			'Should ignore modifiedAt argument'         => array(
-				'data'          => array( 'a' => 'b', 'modifiedAt' => 'c' ),
+				'data'          => array(
+					'a'          => 'b',
+					'modifiedAt' => 'c',
+				),
 				'get_transient' => false,
 				'set_transient' => array( 'a' => 'b' ),
 				'should_skip'   => false,

--- a/tests/phpunit/test-tools/SkipTracking_Tests.php
+++ b/tests/phpunit/test-tools/SkipTracking_Tests.php
@@ -12,14 +12,19 @@ class SkipTracking_Tests extends Base\TestCase {
 	/**
 	 * Test Maybe Skip logic
 	 *
+	 * @backupGlobals enabled
 	 * @covers \SophiWP\ContentSync\maybe_skip_track_event
 	 * @dataProvider data_provider_for_test_maybe_skip
 	 */
-	public function test_maybe_skip( $data, $get_transient, $set_transient, $should_skip ) {
+	public function test_maybe_skip( $data, $get_transient, $set_transient, $should_skip, $metabox = false ) {
 
 		\WP_Mock::userFunction( 'wp_hash' )->andReturn( '' );
 		\WP_Mock::userFunction( 'wp_json_encode' )->andReturn( '' );
 		\WP_Mock::userFunction( 'get_transient' )->andReturn( $get_transient );
+
+		if ( false !== $metabox ) {
+			$_GET['meta-box-loader'] = $metabox;
+		}
 
 		if ( $set_transient ) {
 			\WP_Mock::userFunction( 'set_transient' )->with( 'sophi_tracking_request_', $set_transient, 10 );
@@ -30,6 +35,13 @@ class SkipTracking_Tests extends Base\TestCase {
 
 	public function data_provider_for_test_maybe_skip() {
 		return array(
+			'Should skip if metabox is reloading'       => array(
+				'data'          => array( 'a' => 'b' ),
+				'get_transient' => array( 'c' => 'd' ),
+				'set_transient' => array( 'a' => 'b' ),
+				'should_skip'   => true,
+				'metabox'       => '1',
+			),
 			'Should ignore modifiedAt argument'         => array(
 				'data'          => array(
 					'a'          => 'b',

--- a/tests/phpunit/test-tools/SkipTracking_Tests.php
+++ b/tests/phpunit/test-tools/SkipTracking_Tests.php
@@ -9,29 +9,6 @@ class SkipTracking_Tests extends Base\TestCase {
 		'functions/content-sync.php',
 	);
 
-	public function setUp() :void {
-		\WP_Mock::setUp();
-
-		\WP_Mock::userFunction( 'wp_hash' )->andReturnUsing(
-			function( $data ) {
-				return md5( $data );
-			}
-		);
-
-		\WP_Mock::userFunction( 'wp_json_encode' )->andReturnUsing(
-			function( $data ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Mocking the function
-				return json_encode( $data );
-			}
-		);
-
-		parent::setUp();
-	}
-
-	public function tearDown() :void {
-		\WP_Mock::tearDown();
-	}
-
 	/**
 	 * Test Maybe Skip logic
 	 *


### PR DESCRIPTION
### Description of the Change

This PR adds a transient with default TTL of 10 seconds for every new tracking event. If the transient exists and contain the same data, the tracking event is considered as duplicated call and will be skipped.

Closes #269 

### Verification Process

1. Install and activate: Sophi for WordPress, Debug Bar for Sophi and Yoast SEO plugins
2. Create new post or perform an update of an existing one.
3. Expected to see the single tracking request in Debug Bar 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fixed - Prevent duplicate CMS publish/update event tracking.