### PR TITLE
Modify the `is_configured` check

### DIFF
--- a/includes/functions/settings.php
+++ b/includes/functions/settings.php
@@ -506,15 +506,15 @@ function render_select( $args ) {
  *
  * @return array
  */
-function add_action_links ( $actions ) {
-	if ( ! is_configured() ) {
-		$action_label = __('Set up your Sophi.io account', 'sophi-wp');
+function add_action_links( $actions ) {
+	if ( ! is_configured( 'collector' ) || ! is_configured( 'automation' ) ) {
+		$action_label = __( 'Set up your Sophi.io account', 'sophi-wp' );
 	} else {
-		$action_label = __('Settings', 'sophi-wp');
+		$action_label = __( 'Settings', 'sophi-wp' );
 	}
 	return array_merge(
 		[
-			'<a href="' . admin_url('options-general.php?page=sophi') . '">' . $action_label . '</a>',
+			'<a href="' . admin_url( 'options-general.php?page=sophi' ) . '">' . $action_label . '</a>',
 		],
 		$actions
 	);

--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -254,20 +254,51 @@ function get_supported_post_types() {
 /**
  * Check if Sophi is configured or not.
  *
+ * @param string $section Settings section to check for. Default 'all'.
  * @return bool
  */
-function is_configured() {
+function is_configured( $section = 'all' ) {
 	$settings = get_sophi_settings();
 
-	unset( $settings['environment'] );
-	unset( $settings['query_integration'] );
-
-	$settings = array_filter(
-		$settings,
-		function( $item ) {
-			return empty( $item );
-		}
-	);
+	switch ( $section ) {
+		case 'collector':
+			$settings = array_filter(
+				$settings,
+				function( $item, $key ) {
+					return in_array( $key, [ 'collector_url', 'tracker_address', 'tracker_client_id' ], true ) && empty( $item );
+				},
+				ARRAY_FILTER_USE_BOTH
+			);
+			break;
+		case 'automation':
+			$settings = array_filter(
+				$settings,
+				function( $item, $key ) {
+					return in_array( $key, [ 'host', 'tenant_id', 'site_automation_url' ], true ) && empty( $item );
+				},
+				ARRAY_FILTER_USE_BOTH
+			);
+			break;
+		case 'override':
+			$settings = array_filter(
+				$settings,
+				function( $item, $key ) {
+					return in_array( $key, [ 'sophi_override_url', 'sophi_override_client_id', 'sophi_override_client_secret' ], true ) && empty( $item );
+				},
+				ARRAY_FILTER_USE_BOTH
+			);
+			break;
+		case 'all':
+		default:
+			$settings = array_filter(
+				$settings,
+				function( $item, $key ) {
+					return ! in_array( $key, [ 'environment', 'query_integration' ], true ) && empty( $item );
+				},
+				ARRAY_FILTER_USE_BOTH
+			);
+			break;
+	}
 
 	if ( count( $settings ) > 0 ) {
 		return false;

--- a/sophi.php
+++ b/sophi.php
@@ -63,21 +63,26 @@ add_action(
 			SophiWP\Settings\setup();
 			SophiWP\PostType\setup();
 
-			if ( ! SophiWP\Utils\is_configured() ) {
-				return add_action( 'admin_notices', 'sophi_setup_notice' );
+			if ( ! SophiWP\Utils\is_configured( 'collector' ) || ! SophiWP\Utils\is_configured( 'automation' ) ) {
+				add_action( 'admin_notices', 'sophi_setup_notice' );
 			}
 
-			SophiWP\ContentSync\setup();
-			SophiWP\Tracking\setup();
-			SophiWP\Blocks\setup();
-			( new SophiWP\SiteAutomation\Services() )->register();
+			if ( SophiWP\Utils\is_configured( 'collector' ) ) {
+				SophiWP\ContentSync\setup();
+				SophiWP\Tracking\setup();
 
-			if ( defined( 'WP_CLI' ) && WP_CLI ) {
-				try {
-					\WP_CLI::add_command( 'sophi', 'SophiWP\Command' );
-				} catch ( \Exception $e ) {
-					error_log( $e->getMessage() ); // phpcs:ignore
+				if ( defined( 'WP_CLI' ) && WP_CLI ) {
+					try {
+						\WP_CLI::add_command( 'sophi', 'SophiWP\Command' );
+					} catch ( \Exception $e ) {
+						error_log( $e->getMessage() ); // phpcs:ignore
+					}
 				}
+			}
+
+			if ( SophiWP\Utils\is_configured( 'automation' ) ) {
+				SophiWP\Blocks\setup();
+				( new SophiWP\SiteAutomation\Services() )->register();
 			}
 
 			/**


### PR DESCRIPTION
### Description of the Change

At the moment, before loading any functionality related to content syncing, tracking or blocks, we call our `is_configured` utility function. If that function returns `false`, we don't load the aforementioned functionality and instead we output an admin notice (though only on the WP plugins screen).

The `is_configured` functions checks to see if any settings are blank and if so, returns `false`. This means if any settings aren't in place (like the override settings) no functionality gets loaded.

This PR fixes this by modifying our `is_configured` function to allow checking of each individual section of settings (collector, automation, override or all). We then utilize this to determine what functionality should be loaded as such:

- If any Collector settings are blank, we don't load content syncing, tracking or the WP-CLI command
- If any Automation settings are blank, we don't load our blocks or site automation functionality
- If any Collector or Automation settings are blank, we continue to show our admin notice but we don't stop execution at that point anymore, due to the more strict checks mentioned above

**Note**: this doesn't change any of the validation, saving or output of error messages on the settings page. Those all remain the same.

Closes #356

### Alternate Designs

None

### Possible Drawbacks

Should be none but should verify all functionality loads as expected

### Verification Process

Add and remove various settings and ensure everything works as expected

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Changed - Update our configured check to be smarter

### Credits

Props @dkotter
