### PR TITLE
Hide the override settings

### DIFF
--- a/includes/classes/SiteAutomation/EndPoints.php
+++ b/includes/classes/SiteAutomation/EndPoints.php
@@ -118,8 +118,10 @@ class EndPoints extends WP_REST_Controller {
 		}
 
 		$curated_posts_new = [];
-		foreach ( $curated_posts as $index => $curated_post ) {
-			$curated_posts_new[ $index ] = $this->get_post_details( $curated_post, $rules );
+		if ( is_array( $curated_posts ) ) {
+			foreach ( $curated_posts as $index => $curated_post ) {
+				$curated_posts_new[ $index ] = $this->get_post_details( $curated_post, $rules );
+			}
 		}
 		$curated_posts = $curated_posts_new;
 
@@ -209,8 +211,8 @@ class EndPoints extends WP_REST_Controller {
 	 */
 	public function site_automation_permission(){
 		$current_user = wp_get_current_user();
- 
-		if ( ! $current_user->exists() ) { 
+
+		if ( ! $current_user->exists() ) {
 			return new \WP_Error(401, __( 'Unauthorised user, please log in.', 'sophi-wp' ) );
 		}
 

--- a/includes/functions/settings.php
+++ b/includes/functions/settings.php
@@ -131,7 +131,7 @@ function fields_setup() {
 		SETTINGS_GROUP,
 		'collector_settings',
 		[
-			'label_for' => 'collector_url',
+			'label_for'   => 'collector_url',
 			'description' => __( 'Please use URL without http(s) scheme.', 'sophi-wp' ),
 		]
 	);
@@ -200,6 +200,9 @@ function fields_setup() {
 		]
 	);
 
+	/* // phpcs:ignore
+	Commenting out the Sophi Override settings for now.
+
 	// Add Auth settings section.
 	add_settings_section(
 		'sophi_api_auth',
@@ -241,6 +244,7 @@ function fields_setup() {
 			'description' => __( 'For example, https://xyz.sophi.io/v1/, please add a slash (/) in the end.', 'sophi-wp' ),
 		]
 	);
+	*/
 
 	// Add Advanced settings section.
 	add_settings_section(
@@ -325,13 +329,13 @@ function sanitize_settings( $settings ) {
 		$settings['query_integration'] = 0;
 	}
 
-	if ( empty( $settings['site_automation_url']) ) {
+	if ( empty( $settings['site_automation_url'] ) ) {
 		add_settings_error(
 			SETTINGS_GROUP,
 			SETTINGS_GROUP,
 			__( 'Site Automation URL is required for Site Automation integration.', 'sophi-wp' )
 		);
-	} else if ( ! filter_var( $settings['site_automation_url'], FILTER_VALIDATE_URL ) ) {
+	} elseif ( ! filter_var( $settings['site_automation_url'], FILTER_VALIDATE_URL ) ) {
 		add_settings_error(
 			SETTINGS_GROUP,
 			SETTINGS_GROUP,
@@ -343,26 +347,30 @@ function sanitize_settings( $settings ) {
 		add_settings_error(
 			SETTINGS_GROUP,
 			SETTINGS_GROUP,
+			/* translators: %s is replaced with the tracker URL */
 			sprintf( __( 'Tracker Address URL is invalid: %s', 'sophi-wp' ), $settings['tracker_address'] )
 		);
 		unset( $settings['tracker_address'] );
 	}
 
-	if ( empty( $settings['sophi_override_url']) ) {
+	/* // phpcs:ignore
+	Commenting out the Sophi Override settings for now.
+	if ( empty( $settings['sophi_override_url'] ) ) {
 		add_settings_error(
 			SETTINGS_GROUP,
 			SETTINGS_GROUP,
 			__( 'Sophi Override URL is required for Override actions.', 'sophi-wp' )
 		);
-	} else if ( ! filter_var( $settings['sophi_override_url'], FILTER_VALIDATE_URL ) ) {
+	} elseif ( ! filter_var( $settings['sophi_override_url'], FILTER_VALIDATE_URL ) ) {
 		add_settings_error(
 			SETTINGS_GROUP,
 			SETTINGS_GROUP,
 			__( 'Sophi Override URL is invalid.', 'sophi-wp' )
 		);
 	}
+	*/
 
-	if ( empty( $settings['collector_url']) ) {
+	if ( empty( $settings['collector_url'] ) ) {
 		add_settings_error(
 			SETTINGS_GROUP,
 			SETTINGS_GROUP,
@@ -383,6 +391,8 @@ function sanitize_settings( $settings ) {
 		);
 	}
 
+	/* // phpcs:ignore
+	Commenting out the Sophi Override settings for now.
 	if ( empty( $settings['sophi_override_client_id'] ) || empty( $settings['sophi_override_client_secret'] ) ) {
 		add_settings_error(
 			SETTINGS_GROUP,
@@ -390,6 +400,7 @@ function sanitize_settings( $settings ) {
 			__( 'Both Client ID and Client Secret are required to generate a token for API.', 'sophi-wp' )
 		);
 	}
+	*/
 
 	if ( isset( $settings['client_id'] ) ) {
 		unset( $settings['client_id'] );
@@ -506,15 +517,15 @@ function render_select( $args ) {
  *
  * @return array
  */
-function add_action_links ( $actions ) {
+function add_action_links( $actions ) {
 	if ( ! is_configured() ) {
-		$action_label = __('Set up your Sophi.io account', 'sophi-wp');
+		$action_label = __( 'Set up your Sophi.io account', 'sophi-wp' );
 	} else {
-		$action_label = __('Settings', 'sophi-wp');
+		$action_label = __( 'Settings', 'sophi-wp' );
 	}
 	return array_merge(
 		[
-			'<a href="' . admin_url('options-general.php?page=sophi') . '">' . $action_label . '</a>',
+			'<a href="' . admin_url( 'options-general.php?page=sophi' ) . '">' . $action_label . '</a>',
 		],
 		$actions
 	);


### PR DESCRIPTION
### Description of the Change

Since we are holding on the override functionality for now, this PR hides the settings for those but leaves all other functionality in place (so we can easily turn this back on when ready).

This PR also fixes an issue I found where we may return an empty string instead of an array of posts and this can throw a warning when we try and iterate over that. Also fixes a few PHPCS issues that were being flagged.

Closes #357

### Alternate Designs

Could leave the settings in place and just ignore them

### Possible Drawbacks

Since we've left the block functionality in place, not the best UX since those overrides won't work

### Verification Process

Verify the override settings no longer show up
Verify that the site automation block still works

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Removed - Comment out the override settings for now.
> Fixed - Ensure we have an array of items before iterating over them.

### Credits

Props @dkotter
