### PR TITLE
Fix some primary category issues

### DIFF
--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -142,7 +142,7 @@ function send_track_event( $tracker, $post, $action ) {
 	 * @param {Tracker} $tracker Tracker being used.
 	 * @param {string}  $post    Post object.
 	 * @param {string}  $action  Publishing action.
-	 * 
+	 *
 	 * @return {array} Tracking data to send.
 	 */
 	$data = apply_filters_ref_array( 'sophi_cms_tracking_request_data', array( $data, &$tracker, $post, $action ) );
@@ -224,7 +224,7 @@ function init_tracker() {
 	 * @hook sophi_tracker_emitter_debug
 	 *
 	 * @param {bool} $debug Debug is active.
-	 * 
+	 *
 	 * @return {bool} Whether to turn on emitter debug.
 	 */
 	$debug = apply_filters( 'sophi_tracker_emitter_debug', false );
@@ -276,7 +276,7 @@ function get_post_data( $post ) {
 		'plainText'           => wp_strip_all_tags( $content ),
 		'size'                => str_word_count( wp_strip_all_tags( $content ) ),
 		'allSections'         => Utils\get_post_categories_paths( $post->ID ),
-		'sectionNames'        => array( Utils\get_primary_category( $post->ID ) ),
+		'sectionNames'        => Utils\get_primary_category( $post->ID ) ? [ Utils\get_primary_category( $post->ID ) ] : [],
 		'modifiedAt'          => gmdate( \DateTime::RFC3339, strtotime( $post->post_modified_gmt ) ),
 		'tags'                => Utils\get_post_tags( $post ),
 		'url'                 => $permalink,
@@ -367,7 +367,7 @@ function maybe_skip_track_event( $data ) {
 	 *
 	 * @param {boolean} $skip Whether to skip tracking.
 	 * @param {array}   $data Data to track.
-	 * 
+	 *
 	 * @return {boolean}
 	 */
 	return apply_filters( 'sophi_skip_track_event', $skip, $data );

--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -596,7 +596,5 @@ function get_primary_category( $post_id = 0, $taxonomy = 'category' ) {
 		}
 	}
 
-	$primary_term = yoast_get_primary_term( $taxonomy, $post_id );
-
-	return $primary_term;
+	return yoast_get_primary_term( $taxonomy, $post_id );
 }

--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -583,28 +583,20 @@ function get_wp_sophi_versions() {
  * @param string $taxonomy Optional. The taxonomy to get the primary term ID for. Defaults to category.
  * @param int    $post_id            Optional. Post to get the primary term ID for.
  *
- * @return string|boolean
+ * @return string
  */
 function get_primary_category( $post_id = 0, $taxonomy = 'category' ) {
-	if (
-		! function_exists( 'yoast_get_primary_term_id' ) ||
-		! yoast_get_primary_term_id( $taxonomy, $post_id )
-	) {
+	if ( ! function_exists( 'yoast_get_primary_term' ) || ! yoast_get_primary_term( $taxonomy, $post_id ) ) {
 		$post_terms = wp_get_post_terms( $post_id, $taxonomy );
 
 		if ( is_array( $post_terms ) && count( $post_terms ) > 0 ) {
 			return $post_terms[0]->name;
 		} else {
-			return false;
+			return '';
 		}
 	}
 
-	$primary_term_id  = yoast_get_primary_term_id( $taxonomy, $post_id );
-	$primary_category = get_term( $primary_term_id );
+	$primary_term = yoast_get_primary_term( $taxonomy, $post_id );
 
-	if ( ! is_wp_error( $primary_category ) && ! empty( $primary_category ) ) {
-		return $primary_category->name;
-	}
-
-	return false;
+	return $primary_term;
 }

--- a/includes/functions/utils.php
+++ b/includes/functions/utils.php
@@ -583,21 +583,28 @@ function get_wp_sophi_versions() {
  * @param string $taxonomy Optional. The taxonomy to get the primary term ID for. Defaults to category.
  * @param int    $post_id            Optional. Post to get the primary term ID for.
  *
- * @return string
+ * @return string|boolean
  */
 function get_primary_category( $post_id = 0, $taxonomy = 'category' ) {
-	if ( ! function_exists( 'yoast_get_primary_term_id' ) ) {
+	if (
+		! function_exists( 'yoast_get_primary_term_id' ) ||
+		! yoast_get_primary_term_id( $taxonomy, $post_id )
+	) {
 		$post_terms = wp_get_post_terms( $post_id, $taxonomy );
 
 		if ( is_array( $post_terms ) && count( $post_terms ) > 0 ) {
 			return $post_terms[0]->name;
 		} else {
-			return '';
+			return false;
 		}
 	}
 
 	$primary_term_id  = yoast_get_primary_term_id( $taxonomy, $post_id );
 	$primary_category = get_term( $primary_term_id );
 
-	return $primary_category->name;
+	if ( ! is_wp_error( $primary_category ) && ! empty( $primary_category ) ) {
+		return $primary_category->name;
+	}
+
+	return false;
 }

--- a/tests/phpunit/test-tools/Utils_Tests.php
+++ b/tests/phpunit/test-tools/Utils_Tests.php
@@ -90,24 +90,10 @@ class Core_Tests extends Base\TestCase {
 	}
 
 	public function test_get_primary_category__default_category__yoast_activated() {
-		\WP_Mock::userFunction( 'yoast_get_primary_term_id', array(
+		\WP_Mock::userFunction( 'yoast_get_primary_term', array(
 			'times'  => 2,
 			'args'   => array( 'category', null ),
-			'return' => 123,
-		) );
-
-		\WP_Mock::userFunction( 'get_term', array(
-			'times'  => 1,
-			'args'   => array( 123 ),
-			'return' => (object) array(
-				'term_id' => 123,
-				'name'    => 'Uncategorized',
-			),
-		) );
-
-		\WP_Mock::userFunction( 'is_wp_error', array(
-			'times'  => 1,
-			'return' => false,
+			'return' => 'Uncategorized',
 		) );
 
 		$term_name = get_primary_category();

--- a/tests/phpunit/test-tools/Utils_Tests.php
+++ b/tests/phpunit/test-tools/Utils_Tests.php
@@ -2,7 +2,6 @@
 namespace SophiWP\Utils;
 
 use SophiWP as Base;
-use stdClass;
 
 class Core_Tests extends Base\TestCase {
 

--- a/tests/phpunit/test-tools/Utils_Tests.php
+++ b/tests/phpunit/test-tools/Utils_Tests.php
@@ -2,6 +2,7 @@
 namespace SophiWP\Utils;
 
 use SophiWP as Base;
+use stdClass;
 
 class Core_Tests extends Base\TestCase {
 
@@ -90,7 +91,7 @@ class Core_Tests extends Base\TestCase {
 
 	public function test_get_primary_category__default_category__yoast_activated() {
 		\WP_Mock::userFunction( 'yoast_get_primary_term_id', array(
-			'times'  => 1,
+			'times'  => 2,
 			'args'   => array( 'category', null ),
 			'return' => 123,
 		) );
@@ -102,6 +103,11 @@ class Core_Tests extends Base\TestCase {
 				'term_id' => 123,
 				'name'    => 'Uncategorized',
 			),
+		) );
+
+		\WP_Mock::userFunction( 'is_wp_error', array(
+			'times'  => 1,
+			'return' => false,
 		) );
 
 		$term_name = get_primary_category();


### PR DESCRIPTION
### Description of the Change

This is a follow up to #350.

If Yoast is not being used, everything works as expected. But if Yoast is installed, if no category is selected, we return the value `null`, which breaks our sync. This PR adjust our `get_primary_category` function to add some better checks, ensuring if we don't have a primary category set we fallback to grabbing the first category set. Or if we have a primary category set but that category no longer exists, we now check for that and return `false` instead.

If we return `false` in this function, we've also adjusted the output to the tracker to ensure we are sending an empty array instead of an array with an empty string in it.

### Alternate Designs

None

### Possible Drawbacks

None

### Verification Process

Verify that setting categories sends the correct data to Sophi both with Yoast installed and with it not. Try setting one category, multiple categories and no categories.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
