### PR TITLE
Ensure we don't skip tracking when Yoast updates meta

### DIFF
--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -333,8 +333,11 @@ function maybe_skip_track_event( $data ) {
 	$transient_name = 'sophi_tracking_request_' . $transient_hash;
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	if ( isset( $_GET['meta-box-loader'] ) && $_GET['meta-box-loader'] ) {
-		// Skip if metabox is reloading.
+	if (
+		( isset( $_GET['meta-box-loader'] ) && $_GET['meta-box-loader'] ) &&
+		! filter_input( INPUT_POST, 'yoast_wpseo_primary_category_term', FILTER_SANITIZE_NUMBER_INT )
+	) {
+		// Skip if metabox is reloading and we're not saving the primary category.
 		$skip = true;
 	} elseif ( get_transient( $transient_name ) === $data ) {
 		// Skip duplicated track within last 10 seconds.

--- a/includes/functions/content-sync.php
+++ b/includes/functions/content-sync.php
@@ -333,10 +333,8 @@ function maybe_skip_track_event( $data ) {
 	$transient_name = 'sophi_tracking_request_' . $transient_hash;
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	if (
-		( isset( $_GET['meta-box-loader'] ) && $_GET['meta-box-loader'] ) &&
-		! filter_input( INPUT_POST, 'yoast_wpseo_primary_category_term', FILTER_SANITIZE_NUMBER_INT )
-	) {
+	if ( ( isset( $_GET['meta-box-loader'] ) && $_GET['meta-box-loader'] ) &&
+		! filter_input( INPUT_POST, 'yoast_wpseo_primary_category_term', FILTER_SANITIZE_NUMBER_INT ) ) {
 		// Skip if metabox is reloading and we're not saving the primary category.
 		$skip = true;
 	} elseif ( get_transient( $transient_name ) === $data ) {


### PR DESCRIPTION
### Description of the Change

If using Yoast, the primary category data is saved by making a second request whenever content is saved. In #335, functionality was added to skip duplicate tracking events. But this also skips those updates from Yoast which now means you don't accurately track category information (unless you save twice).

This PR modifies the functionality introduced in #335 slightly so instead of always skipping tracking during those second requests, we only skip those if the primary category data isn't being saved.

**Note**: this does mean for those using Yoast, two tracking requests will be sent to Sophi each time content is saved. May be worth finding a better solution for this in the future.

**Also note**: there may come a time in the future where some other data is needed that is saved the same way (using the legacy meta box feature). The code change here only allows the Yoast primary category data to trigger a duplicate tracking event. Just something to hopefully remember in case this comes up again.

### Alternate Designs

Could refactor how we send tracking events to wait until all data has been saved before we send a tracking event. This would remove all chance of duplicates but it is more effort and only solves this single use case at the moment.

### Possible Drawbacks

For those using Yoast, duplicate tracking events will be sent

### Verification Process

Test with both Yoast active and not active, adding and removing categories and ensuring those are tracked correctly.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

> Fixed - Ensure we send tracking events when the Yoast featured category data is saved.

### Credits

Props @dkotter
